### PR TITLE
Feature: 로그인, 내 정보 조회 스웨거 명세 작성 (#12)

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/user/controller/AuthController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/user/controller/AuthController.java
@@ -1,0 +1,20 @@
+package com.blaybus.blaybusbe.domain.user.controller;
+
+import com.blaybus.blaybusbe.domain.user.controller.api.AuthApi;
+import com.blaybus.blaybusbe.global.security.LoginFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+
+    /**
+     * 로그인 기능
+     * @param loginDto: username(아이디), password(비밀번호)
+     */
+    @PostMapping("/auth/login")
+    public void login(@RequestBody LoginFilter.LoginDto loginDto) {}
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/user/controller/UserController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.blaybus.blaybusbe.domain.user.controller;
 
+import com.blaybus.blaybusbe.domain.user.controller.api.UserApi;
 import com.blaybus.blaybusbe.domain.user.dto.response.ResponseUserDto;
 import com.blaybus.blaybusbe.domain.user.service.UserService;
 import com.blaybus.blaybusbe.global.security.CustomUserDetails;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserApi {
 
     private final UserService userService;
 

--- a/src/main/java/com/blaybus/blaybusbe/domain/user/controller/api/AuthApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/user/controller/api/AuthApi.java
@@ -1,0 +1,24 @@
+package com.blaybus.blaybusbe.domain.user.controller.api;
+
+import com.blaybus.blaybusbe.global.security.LoginFilter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Authentication API", description = "인증 관련 API (로그인, 로그아웃)")
+public interface AuthApi {
+
+    @Operation(summary = "로그인", description = "아이디와 비밀번호를 입력하여 로그인합니다. " +
+            "(성공 시 Authorization: 'Bearer AccessToken' 발급)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공 (Authorization Header 확인)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 실패 (아이디 또는 비밀번호 불일치)", content = @Content)
+    })
+    void login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "로그인 정보", required = true)
+            @RequestBody LoginFilter.LoginDto loginDto
+    );
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/user/controller/api/UserApi.java
@@ -1,0 +1,30 @@
+package com.blaybus.blaybusbe.domain.user.controller.api;
+
+import com.blaybus.blaybusbe.domain.user.dto.response.ResponseUserDto;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "회원 관련 API", description = "회원 관련(조회, 수정, 탈퇴) 기능 API")
+public interface UserApi {
+
+    @Operation(summary = "회원 정보 조회", description = "회원 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ResponseUserDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+    })
+    ResponseEntity<ResponseUserDto> findUser(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+}

--- a/src/main/java/com/blaybus/blaybusbe/global/security/LoginFilter.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/security/LoginFilter.java
@@ -74,7 +74,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     @Getter
     @Setter
-    private static class LoginDto {
+    public static class LoginDto {
         private String username;
         private String password;
     }


### PR DESCRIPTION
##  구현 내용
1. **인증(Auth) 관련 API 문서화**
    * `/auth/login`: 로그인 성공 시 발급되는 JWT Access Token의 구조와 응답 예시를 상세히 기술했습니다.
2. **유저(User) 관련 API 문서화**
    * `/users/me`: 현재 로그인한 사용자의 정보를 조회하는 API 명세를 작성했습니다.
    * 해당 API 호출 시 **JWT 인증이 필수**임을 명시하고, Swagger UI 내에서 직접 테스트 가능하도록 설정했습니다.
3. **Swagger UI 최적화 및 그룹화**
    * Api 인터페이스에서 `@Tag`를 사용하여 `Auth`와 `User` 컨트롤러를 논리적으로 분리하여 가독성을 개선했습니다.
    * 데이터 모델에 `@Schema`를 적용하여 각 필드의 역할과 제약 조건을 설명했습니다.

##  기술적 선택 및 특이사항
* **보안 스키마 통합**: `SwaggerConfig`의 `bearer-jwt` 설정을 기반으로 전역 보안 설정을 완료하여, 인증이 필요한 API 상단에 자물쇠 아이콘이 표시되도록 연동했습니다.
* **로그아웃 처리**: Access Token만 사용하는 Stateless 방식의 특성을 고려하여 별도의 서버 로그아웃 API는 구현하지 않았습니다. 대신 클라이언트(프론트엔드)에서 스토리지의 토큰을 파기하는 방식을 가이드라인으로 채택했습니다.

##  테스트 결과
* `http://localhost:8080/swagger-ui/index.html` 접속 시 모든 API 명세가 의도대로 노출됨을 확인했습니다.
* Swagger UI의 `Authorize` 기능을 통해 발급받은 토큰을 주입한 뒤, '내 정보 조회 API'가 정상적으로 유저 데이터를 반환하는 것을 테스트 완료했습니다.

###  팀원 안내 사항
* 로그인 성공 시 authorization: Bearer token 형식으로 응답받습니다. 스웨거에 토큰 주입 시 Bearer를 자동으로 붙여주기 때문에 token만 붙여넣으시면 되고 Postman등 테스트 시 Bearer+token 모두 붙여넣으시면 됩니다.