### PR TITLE
Feature: Task 도메인 구현 (#21)

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/mentoring/entity/MenteeInfo.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/mentoring/entity/MenteeInfo.java
@@ -1,0 +1,49 @@
+package com.blaybus.blaybusbe.domain.mentoring.entity;
+
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "mentee_info")
+public class MenteeInfo extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "school_name", nullable = false, length = 30)
+    private String schoolName;
+
+    @Column(name = "korean_grade")
+    private Integer koreanGrade;
+
+    @Column(name = "math_grade")
+    private Integer mathGrade;
+
+    @Column(name = "english_grade")
+    private Integer englishGrade;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id", nullable = false)
+    private User mentor;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentee_id", nullable = false, unique = true)
+    private User mentee;
+
+    @Builder
+    public MenteeInfo(String schoolName, Integer koreanGrade, Integer mathGrade, Integer englishGrade, User mentor, User mentee) {
+        this.schoolName = schoolName;
+        this.koreanGrade = koreanGrade;
+        this.mathGrade = mathGrade;
+        this.englishGrade = englishGrade;
+        this.mentor = mentor;
+        this.mentee = mentee;
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/mentoring/repository/MenteeInfoRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/mentoring/repository/MenteeInfoRepository.java
@@ -1,0 +1,13 @@
+package com.blaybus.blaybusbe.domain.mentoring.repository;
+
+import com.blaybus.blaybusbe.domain.mentoring.entity.MenteeInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MenteeInfoRepository extends JpaRepository<MenteeInfo, Long> {
+
+    Optional<MenteeInfo> findByMenteeId(Long menteeId);
+
+    boolean existsByMentorIdAndMenteeId(Long mentorId, Long menteeId);
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/PlanController.java
@@ -73,6 +73,18 @@ public class PlanController implements PlanApi {
     }
 
     @Override
+    @GetMapping("/calendar/weekly")
+    public ResponseEntity<List<PlanResponse>> getWeeklyCalendar(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(required = false) Long menteeId,
+            @RequestParam String date
+    ) {
+        Long targetMenteeId = menteeId != null ? menteeId : user.getId();
+        LocalDate targetDate = LocalDate.parse(date);
+        return ResponseEntity.ok(planService.getWeeklyCalendar(targetMenteeId, targetDate));
+    }
+
+    @Override
     @PutMapping("/{planId}")
     public ResponseEntity<PlanResponse> updatePlan(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/api/PlanApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/api/PlanApi.java
@@ -64,6 +64,17 @@ public interface PlanApi {
             @RequestParam int month
     );
 
+    @Operation(summary = "주간 캘린더 조회", description = "특정 날짜가 포함된 주(월~일)의 플래너와 할 일 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "주간 캘린더 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
+    })
+    ResponseEntity<List<PlanResponse>> getWeeklyCalendar(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(required = false) Long menteeId,
+            @Parameter(description = "조회 기준 날짜 (yyyy-MM-dd)") @RequestParam String date
+    );
+
     @Operation(summary = "플래너 수정", description = "플래너 메모를 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "플래너 수정 성공",

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/PlanResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/PlanResponse.java
@@ -1,10 +1,13 @@
 package com.blaybus.blaybusbe.domain.plan.dto.response;
 
 import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
+import com.blaybus.blaybusbe.domain.task.dto.response.TaskResponse;
+import com.blaybus.blaybusbe.domain.task.entity.Task;
 import lombok.Builder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record PlanResponse(
@@ -14,10 +17,11 @@ public record PlanResponse(
         String dailyMemo,
         String mentorFeedback,
         Long menteeId,
+        List<TaskResponse> tasks,
         LocalDateTime createdAt
 ) {
 
-    public static PlanResponse from(DailyPlan plan) {
+    public static PlanResponse from(DailyPlan plan, List<Task> taskList) {
         return PlanResponse.builder()
                 .id(plan.getId())
                 .planDate(plan.getPlanDate())
@@ -25,6 +29,7 @@ public record PlanResponse(
                 .dailyMemo(plan.getDailyMemo())
                 .mentorFeedback(plan.getMentorFeedback())
                 .menteeId(plan.getMentee().getId())
+                .tasks(taskList.stream().map(TaskResponse::from).toList())
                 .createdAt(plan.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
@@ -1,0 +1,123 @@
+package com.blaybus.blaybusbe.domain.task.controller;
+
+import com.blaybus.blaybusbe.domain.task.controller.api.TaskApi;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateMenteeTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateMentorTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateRecurringTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.UpdateTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.response.RecurringTaskResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TaskResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TimerResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TimerStopResponse;
+import com.blaybus.blaybusbe.domain.task.service.TaskService;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TaskController implements TaskApi {
+
+    private final TaskService taskService;
+
+    @Override
+    @PostMapping("/tasks/{menteeId}")
+    public ResponseEntity<TaskResponse> createMentorTask(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long menteeId,
+            @RequestBody CreateMentorTaskRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(taskService.createMentorTask(user.getId(), menteeId, request));
+    }
+
+    @Override
+    @PostMapping("/tasks")
+    public ResponseEntity<TaskResponse> createMenteeTask(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody CreateMenteeTaskRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(taskService.createMenteeTask(user.getId(), request));
+    }
+
+    @Override
+    @GetMapping("/tasks/{taskId}")
+    public ResponseEntity<TaskResponse> getTask(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId
+    ) {
+        return ResponseEntity.ok(taskService.getTask(taskId));
+    }
+
+    @Override
+    @PutMapping("/tasks/{taskId}")
+    public ResponseEntity<TaskResponse> updateTask(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId,
+            @RequestBody UpdateTaskRequest request
+    ) {
+        return ResponseEntity.ok(taskService.updateTask(user.getId(), user.getRole(), taskId, request));
+    }
+
+    @Override
+    @DeleteMapping("/tasks/{taskId}")
+    public ResponseEntity<Void> deleteTask(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId
+    ) {
+        taskService.deleteTask(user.getId(), user.getRole(), taskId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @PatchMapping("/mentor/tasks/{taskId}/confirm")
+    public ResponseEntity<TaskResponse> confirmTask(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId
+    ) {
+        return ResponseEntity.ok(taskService.confirmTask(user.getId(), taskId));
+    }
+
+    @Override
+    @PatchMapping("/tasks/{taskId}/timer/start")
+    public ResponseEntity<TimerResponse> startTimer(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId
+    ) {
+        return ResponseEntity.ok(taskService.startTimer(user.getId(), taskId));
+    }
+
+    @Override
+    @PatchMapping("/tasks/{taskId}/timer/stop")
+    public ResponseEntity<TimerStopResponse> stopTimer(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId
+    ) {
+        return ResponseEntity.ok(taskService.stopTimer(user.getId(), taskId));
+    }
+
+    @Override
+    @PostMapping("/mentor/mentee/{menteeId}/recurring-tasks")
+    public ResponseEntity<RecurringTaskResponse> createRecurringTasks(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long menteeId,
+            @RequestBody CreateRecurringTaskRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(taskService.createRecurringTasks(user.getId(), menteeId, request));
+    }
+
+    @Override
+    @DeleteMapping("/mentor/recurring-tasks/{recurringGroupId}")
+    public ResponseEntity<Void> deleteRecurringTasks(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable String recurringGroupId
+    ) {
+        taskService.deleteRecurringTasks(user.getId(), recurringGroupId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
@@ -1,0 +1,144 @@
+package com.blaybus.blaybusbe.domain.task.controller.api;
+
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateMenteeTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateMentorTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateRecurringTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.UpdateTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.response.RecurringTaskResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TaskResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TimerResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TimerStopResponse;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "과제/할일 API", description = "멘토 과제 출제, 멘티 할 일 추가, 타이머, 반복 과제 API")
+public interface TaskApi {
+
+    @Operation(summary = "멘토 과제 출제", description = "멘토가 멘티에게 과제를 출제합니다. (is_fixed=true)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "과제 출제 성공",
+                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "멘토-멘티 매핑 없음", content = @Content)
+    })
+    ResponseEntity<TaskResponse> createMentorTask(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "멘티 ID") @PathVariable Long menteeId,
+            @RequestBody CreateMentorTaskRequest request
+    );
+
+    @Operation(summary = "멘티 할 일 추가", description = "멘티가 본인 캘린더에 할 일을 추가합니다. (is_fixed=false)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "할 일 추가 성공",
+                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
+    })
+    ResponseEntity<TaskResponse> createMenteeTask(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody CreateMenteeTaskRequest request
+    );
+
+    @Operation(summary = "과제 상세 조회", description = "과제/할 일 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
+            @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
+    })
+    ResponseEntity<TaskResponse> getTask(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId
+    );
+
+    @Operation(summary = "과제 수정", description = "과제/할 일을 수정합니다. 고정 과제는 멘토만 수정 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
+    })
+    ResponseEntity<TaskResponse> updateTask(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId,
+            @RequestBody UpdateTaskRequest request
+    );
+
+    @Operation(summary = "과제 삭제", description = "과제/할 일을 삭제합니다. 고정 과제는 멘토만 삭제 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
+    })
+    ResponseEntity<Void> deleteTask(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId
+    );
+
+    @Operation(summary = "멘토 확인 체크 토글", description = "멘토가 과제 확인 여부를 토글합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토글 성공",
+                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
+    })
+    ResponseEntity<TaskResponse> confirmTask(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId
+    );
+
+    @Operation(summary = "타이머 시작", description = "과제 타이머를 시작합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "타이머 시작 성공",
+                    content = @Content(schema = @Schema(implementation = TimerResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 실행 중", content = @Content)
+    })
+    ResponseEntity<TimerResponse> startTimer(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId
+    );
+
+    @Operation(summary = "타이머 종료", description = "과제 타이머를 종료하고 시간을 누적합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "타이머 종료 성공",
+                    content = @Content(schema = @Schema(implementation = TimerStopResponse.class))),
+            @ApiResponse(responseCode = "409", description = "실행 중이 아님", content = @Content)
+    })
+    ResponseEntity<TimerStopResponse> stopTimer(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId
+    );
+
+    @Operation(summary = "반복 과제 일괄 생성", description = "멘토가 기간/요일을 지정하여 반복 과제를 일괄 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "반복 과제 생성 성공",
+                    content = @Content(schema = @Schema(implementation = RecurringTaskResponse.class))),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "멘토-멘티 매핑 없음", content = @Content)
+    })
+    ResponseEntity<RecurringTaskResponse> createRecurringTasks(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "멘티 ID") @PathVariable Long menteeId,
+            @RequestBody CreateRecurringTaskRequest request
+    );
+
+    @Operation(summary = "반복 과제 그룹 삭제", description = "같은 반복 그룹의 과제를 일괄 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "반복 그룹 없음", content = @Content)
+    })
+    ResponseEntity<Void> deleteRecurringTasks(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "반복 그룹 ID") @PathVariable String recurringGroupId
+    );
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateMenteeTaskRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateMenteeTaskRequest.java
@@ -1,0 +1,14 @@
+package com.blaybus.blaybusbe.domain.task.dto.request;
+
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+
+import java.time.LocalDate;
+
+public record CreateMenteeTaskRequest(
+        LocalDate date,
+        String title,
+        Subject subject,
+        String goal,
+        String description
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateMentorTaskRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateMentorTaskRequest.java
@@ -1,0 +1,20 @@
+package com.blaybus.blaybusbe.domain.task.dto.request;
+
+import com.blaybus.blaybusbe.domain.task.enums.DayOfWeekEnum;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+
+import java.time.LocalDate;
+
+public record CreateMentorTaskRequest(
+        LocalDate date,
+        String title,
+        Subject subject,
+        String goal,
+        String description,
+        Integer weekNumber,
+        DayOfWeekEnum dayOfWeek,
+        Long weaknessId,
+        Long studyMaterialId,
+        Boolean isMandatory
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateRecurringTaskRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateRecurringTaskRequest.java
@@ -1,0 +1,20 @@
+package com.blaybus.blaybusbe.domain.task.dto.request;
+
+import com.blaybus.blaybusbe.domain.task.enums.DayOfWeekEnum;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreateRecurringTaskRequest(
+        LocalDate startDate,
+        LocalDate endDate,
+        List<DayOfWeekEnum> daysOfWeek,
+        Subject subject,
+        String title,
+        String goal,
+        String description,
+        Long weaknessId,
+        Boolean isMandatory
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/UpdateTaskRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/UpdateTaskRequest.java
@@ -1,0 +1,14 @@
+package com.blaybus.blaybusbe.domain.task.dto.request;
+
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+import com.blaybus.blaybusbe.domain.task.enums.TaskStatus;
+
+public record UpdateTaskRequest(
+        String title,
+        Subject subject,
+        String goal,
+        String description,
+        TaskStatus status,
+        Boolean isMandatory
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/RecurringTaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/RecurringTaskResponse.java
@@ -1,0 +1,13 @@
+package com.blaybus.blaybusbe.domain.task.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RecurringTaskResponse(
+        String recurringGroupId,
+        Integer taskCount,
+        List<Long> taskIds
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
@@ -1,0 +1,62 @@
+package com.blaybus.blaybusbe.domain.task.dto.response;
+
+import com.blaybus.blaybusbe.domain.task.entity.Task;
+import com.blaybus.blaybusbe.domain.task.enums.*;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record TaskResponse(
+        Long id,
+        Subject subject,
+        String title,
+        TaskStatus status,
+        Integer actualStudyTime,
+        LocalDate taskDate,
+        Boolean isFixed,
+        Boolean isMentorChecked,
+        Boolean isMandatory,
+        String goal,
+        String description,
+        Integer weekNumber,
+        DayOfWeekEnum dayOfWeek,
+        String recurringGroupId,
+        TimerStatus timerStatus,
+        Long contentId,
+        Long weaknessId,
+        Long dailyPlanId,
+        Long menteeId,
+        Boolean submitted,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static TaskResponse from(Task task) {
+        return TaskResponse.builder()
+                .id(task.getId())
+                .subject(task.getSubject())
+                .title(task.getTitle())
+                .status(task.getStatus())
+                .actualStudyTime(task.getActualStudyTime())
+                .taskDate(task.getTaskDate())
+                .isFixed(task.getIsFixed())
+                .isMentorChecked(task.getIsMentorChecked())
+                .isMandatory(task.getIsMandatory())
+                .goal(task.getGoal())
+                .description(task.getDescription())
+                .weekNumber(task.getWeekNumber())
+                .dayOfWeek(task.getDayOfWeek())
+                .recurringGroupId(task.getRecurringGroupId())
+                .timerStatus(task.getTimerStatus())
+                .contentId(task.getContentId())
+                .weaknessId(task.getWeaknessId())
+                .dailyPlanId(task.getDailyPlan().getId())
+                .menteeId(task.getMentee().getId())
+                .submitted(false) // Submission 도메인 미구현 → 항상 false
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerResponse.java
@@ -1,0 +1,14 @@
+package com.blaybus.blaybusbe.domain.task.dto.response;
+
+import com.blaybus.blaybusbe.domain.task.enums.TimerStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record TimerResponse(
+        Long taskId,
+        TimerStatus timerStatus,
+        LocalDateTime timerStartedAt
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerStopResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerStopResponse.java
@@ -1,0 +1,11 @@
+package com.blaybus.blaybusbe.domain.task.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TimerStopResponse(
+        Long taskId,
+        Integer sessionMinutes,
+        Integer accumulatedMinutes
+) {
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
@@ -1,0 +1,117 @@
+package com.blaybus.blaybusbe.domain.task.entity;
+
+import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
+import com.blaybus.blaybusbe.domain.task.enums.DayOfWeekEnum;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+import com.blaybus.blaybusbe.domain.task.enums.TaskStatus;
+import com.blaybus.blaybusbe.domain.task.enums.TimerStatus;
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "tasks")
+public class Task extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Subject subject;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TaskStatus status = TaskStatus.TODO;
+
+    @Column(name = "actual_study_time", nullable = false)
+    private Integer actualStudyTime = 0;
+
+    @Column(name = "task_date", nullable = false)
+    private LocalDate taskDate;
+
+    @Column(name = "is_fixed", nullable = false)
+    private Boolean isFixed = false;
+
+    @Column(name = "is_mentor_checked", nullable = false)
+    private Boolean isMentorChecked = false;
+
+    @Column(name = "is_mandatory", nullable = false)
+    private Boolean isMandatory = false;
+
+    @Column(columnDefinition = "TEXT")
+    private String goal;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "week_number")
+    private Integer weekNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week")
+    private DayOfWeekEnum dayOfWeek;
+
+    @Column(name = "recurring_group_id")
+    private String recurringGroupId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "timer_status", nullable = false)
+    private TimerStatus timerStatus = TimerStatus.STOPPED;
+
+    @Column(name = "timer_started_at")
+    private LocalDateTime timerStartedAt;
+
+    @Column(name = "content_id")
+    private Long contentId;
+
+    @Column(name = "weakness_id")
+    private Long weaknessId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_planner_id", nullable = false)
+    private DailyPlan dailyPlan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentee_id", nullable = false)
+    private User mentee;
+
+    @Builder
+    public Task(Subject subject, String title, LocalDate taskDate, Boolean isFixed,
+                Boolean isMandatory, String goal, String description,
+                Integer weekNumber, DayOfWeekEnum dayOfWeek, String recurringGroupId,
+                Long contentId, Long weaknessId, DailyPlan dailyPlan, User mentee) {
+        this.subject = subject;
+        this.title = title;
+        this.taskDate = taskDate;
+        this.isFixed = isFixed;
+        this.isMandatory = isMandatory != null ? isMandatory : false;
+        this.goal = goal;
+        this.description = description;
+        this.weekNumber = weekNumber;
+        this.dayOfWeek = dayOfWeek;
+        this.recurringGroupId = recurringGroupId;
+        this.contentId = contentId;
+        this.weaknessId = weaknessId;
+        this.dailyPlan = dailyPlan;
+        this.mentee = mentee;
+        this.status = TaskStatus.TODO;
+        this.actualStudyTime = 0;
+        this.isMentorChecked = false;
+        this.timerStatus = TimerStatus.STOPPED;
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/enums/DayOfWeekEnum.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/enums/DayOfWeekEnum.java
@@ -1,0 +1,23 @@
+package com.blaybus.blaybusbe.domain.task.enums;
+
+import java.time.DayOfWeek;
+
+public enum DayOfWeekEnum {
+    MON(DayOfWeek.MONDAY),
+    TUE(DayOfWeek.TUESDAY),
+    WED(DayOfWeek.WEDNESDAY),
+    THU(DayOfWeek.THURSDAY),
+    FRI(DayOfWeek.FRIDAY),
+    SAT(DayOfWeek.SATURDAY),
+    SUN(DayOfWeek.SUNDAY);
+
+    private final DayOfWeek dayOfWeek;
+
+    DayOfWeekEnum(DayOfWeek dayOfWeek) {
+        this.dayOfWeek = dayOfWeek;
+    }
+
+    public DayOfWeek toDayOfWeek() {
+        return dayOfWeek;
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/enums/Subject.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/enums/Subject.java
@@ -1,0 +1,5 @@
+package com.blaybus.blaybusbe.domain.task.enums;
+
+public enum Subject {
+    KOREAN, ENGLISH, MATH, OTHER
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/enums/TaskStatus.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/enums/TaskStatus.java
@@ -1,0 +1,5 @@
+package com.blaybus.blaybusbe.domain.task.enums;
+
+public enum TaskStatus {
+    TODO, IN_PROGRESS, DONE
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/enums/TimerStatus.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/enums/TimerStatus.java
@@ -1,0 +1,5 @@
+package com.blaybus.blaybusbe.domain.task.enums;
+
+public enum TimerStatus {
+    STOPPED, RUNNING
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/repository/TaskRepository.java
@@ -1,0 +1,17 @@
+package com.blaybus.blaybusbe.domain.task.repository;
+
+import com.blaybus.blaybusbe.domain.task.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    List<Task> findByDailyPlanId(Long dailyPlanId);
+
+    List<Task> findByMenteeIdAndTaskDate(Long menteeId, LocalDate taskDate);
+
+    List<Task> findByRecurringGroupId(String recurringGroupId);
+
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
@@ -1,0 +1,331 @@
+package com.blaybus.blaybusbe.domain.task.service;
+
+import com.blaybus.blaybusbe.domain.mentoring.repository.MenteeInfoRepository;
+import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
+import com.blaybus.blaybusbe.domain.plan.repository.DailyPlanRepository;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateMenteeTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateMentorTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.CreateRecurringTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.request.UpdateTaskRequest;
+import com.blaybus.blaybusbe.domain.task.dto.response.RecurringTaskResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TaskResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TimerResponse;
+import com.blaybus.blaybusbe.domain.task.dto.response.TimerStopResponse;
+import com.blaybus.blaybusbe.domain.task.entity.Task;
+import com.blaybus.blaybusbe.domain.task.enums.DayOfWeekEnum;
+import com.blaybus.blaybusbe.domain.task.enums.TimerStatus;
+import com.blaybus.blaybusbe.domain.task.repository.TaskRepository;
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.domain.user.enums.Role;
+import com.blaybus.blaybusbe.domain.user.repository.UserRepository;
+import com.blaybus.blaybusbe.global.exception.CustomException;
+import com.blaybus.blaybusbe.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TaskService {
+
+    private final TaskRepository taskRepository;
+    private final DailyPlanRepository dailyPlanRepository;
+    private final UserRepository userRepository;
+    private final MenteeInfoRepository menteeInfoRepository;
+
+    /**
+     * 멘토 과제 출제 (is_fixed=true)
+     */
+    public TaskResponse createMentorTask(Long mentorId, Long menteeId, CreateMentorTaskRequest request) {
+        // 멘토-멘티 매핑 검증
+        if (!menteeInfoRepository.existsByMentorIdAndMenteeId(mentorId, menteeId)) {
+            throw new CustomException(ErrorCode.MENTEE_INFO_NOT_FOUND);
+        }
+
+        User mentee = userRepository.findById(menteeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        DailyPlan dailyPlan = findOrCreateDailyPlan(mentee, request.date());
+
+        Task task = Task.builder()
+                .subject(request.subject())
+                .title(request.title())
+                .taskDate(request.date())
+                .isFixed(true)
+                .isMandatory(request.isMandatory())
+                .goal(request.goal())
+                .description(request.description())
+                .weekNumber(request.weekNumber())
+                .dayOfWeek(request.dayOfWeek())
+                .weaknessId(request.weaknessId())
+                .contentId(request.studyMaterialId())
+                .dailyPlan(dailyPlan)
+                .mentee(mentee)
+                .build();
+
+        taskRepository.save(task);
+        return TaskResponse.from(task);
+    }
+
+    /**
+     * 멘티 할 일 추가 (is_fixed=false)
+     */
+    public TaskResponse createMenteeTask(Long menteeId, CreateMenteeTaskRequest request) {
+        User mentee = userRepository.findById(menteeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        DailyPlan dailyPlan = findOrCreateDailyPlan(mentee, request.date());
+
+        Task task = Task.builder()
+                .subject(request.subject())
+                .title(request.title())
+                .taskDate(request.date())
+                .isFixed(false)
+                .goal(request.goal())
+                .description(request.description())
+                .dailyPlan(dailyPlan)
+                .mentee(mentee)
+                .build();
+
+        taskRepository.save(task);
+        return TaskResponse.from(task);
+    }
+
+    /**
+     * 과제 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public TaskResponse getTask(Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+        return TaskResponse.from(task);
+    }
+
+    /**
+     * 과제 수정
+     * - 고정 과제(is_fixed=true): 멘토만 수정 가능
+     * - 비고정 과제(is_fixed=false): 멘티 본인만 수정 가능
+     */
+    public TaskResponse updateTask(Long userId, Role role, Long taskId, UpdateTaskRequest request) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
+        validateTaskModifyPermission(task, userId, role);
+
+        if (request.title() != null) task.setTitle(request.title());
+        if (request.subject() != null) task.setSubject(request.subject());
+        if (request.goal() != null) task.setGoal(request.goal());
+        if (request.description() != null) task.setDescription(request.description());
+        if (request.status() != null) task.setStatus(request.status());
+        if (request.isMandatory() != null) task.setIsMandatory(request.isMandatory());
+
+        return TaskResponse.from(task);
+    }
+
+    /**
+     * 과제 삭제
+     */
+    public void deleteTask(Long userId, Role role, Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
+        validateTaskModifyPermission(task, userId, role);
+
+        taskRepository.delete(task);
+    }
+
+    /**
+     * 멘토 확인 체크 토글
+     */
+    public TaskResponse confirmTask(Long mentorId, Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
+        // 멘토-멘티 매핑 검증
+        if (!menteeInfoRepository.existsByMentorIdAndMenteeId(mentorId, task.getMentee().getId())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        task.setIsMentorChecked(!task.getIsMentorChecked());
+        return TaskResponse.from(task);
+    }
+
+    /**
+     * 타이머 시작
+     */
+    public TimerResponse startTimer(Long menteeId, Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
+        if (!task.getMentee().getId().equals(menteeId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        if (task.getTimerStatus() == TimerStatus.RUNNING) {
+            throw new CustomException(ErrorCode.TIMER_ALREADY_RUNNING);
+        }
+
+        task.setTimerStatus(TimerStatus.RUNNING);
+        task.setTimerStartedAt(LocalDateTime.now());
+
+        // 타이머 시작 시 상태를 IN_PROGRESS로 변경
+        if (task.getStatus() == com.blaybus.blaybusbe.domain.task.enums.TaskStatus.TODO) {
+            task.setStatus(com.blaybus.blaybusbe.domain.task.enums.TaskStatus.IN_PROGRESS);
+        }
+
+        return TimerResponse.builder()
+                .taskId(task.getId())
+                .timerStatus(task.getTimerStatus())
+                .timerStartedAt(task.getTimerStartedAt())
+                .build();
+    }
+
+    /**
+     * 타이머 종료 (세션 시간 누적)
+     */
+    public TimerStopResponse stopTimer(Long menteeId, Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
+        if (!task.getMentee().getId().equals(menteeId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        if (task.getTimerStatus() == TimerStatus.STOPPED) {
+            throw new CustomException(ErrorCode.TIMER_NOT_RUNNING);
+        }
+
+        // 세션 시간 계산 (분 단위)
+        long sessionMinutes = Duration.between(task.getTimerStartedAt(), LocalDateTime.now()).toMinutes();
+        int sessionMin = (int) sessionMinutes;
+
+        // 누적 시간 갱신
+        task.setActualStudyTime(task.getActualStudyTime() + sessionMin);
+        task.setTimerStatus(TimerStatus.STOPPED);
+        task.setTimerStartedAt(null);
+
+        // DailyPlan의 totalStudyTime도 갱신
+        DailyPlan dailyPlan = task.getDailyPlan();
+        dailyPlan.setTotalStudyTime(dailyPlan.getTotalStudyTime() + sessionMin);
+
+        return TimerStopResponse.builder()
+                .taskId(task.getId())
+                .sessionMinutes(sessionMin)
+                .accumulatedMinutes(task.getActualStudyTime())
+                .build();
+    }
+
+    /**
+     * 반복 과제 일괄 생성
+     */
+    public RecurringTaskResponse createRecurringTasks(Long mentorId, Long menteeId, CreateRecurringTaskRequest request) {
+        // 멘토-멘티 매핑 검증
+        if (!menteeInfoRepository.existsByMentorIdAndMenteeId(mentorId, menteeId)) {
+            throw new CustomException(ErrorCode.MENTEE_INFO_NOT_FOUND);
+        }
+
+        User mentee = userRepository.findById(menteeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String groupId = UUID.randomUUID().toString();
+        List<Long> taskIds = new ArrayList<>();
+
+        LocalDate current = request.startDate();
+        while (!current.isAfter(request.endDate())) {
+            for (DayOfWeekEnum day : request.daysOfWeek()) {
+                if (current.getDayOfWeek() == day.toDayOfWeek()) {
+                    DailyPlan dailyPlan = findOrCreateDailyPlan(mentee, current);
+
+                    Task task = Task.builder()
+                            .subject(request.subject())
+                            .title(request.title())
+                            .taskDate(current)
+                            .isFixed(true)
+                            .isMandatory(request.isMandatory())
+                            .goal(request.goal())
+                            .description(request.description())
+                            .weaknessId(request.weaknessId())
+                            .recurringGroupId(groupId)
+                            .dailyPlan(dailyPlan)
+                            .mentee(mentee)
+                            .build();
+
+                    taskRepository.save(task);
+                    taskIds.add(task.getId());
+                }
+            }
+            current = current.plusDays(1);
+        }
+
+        return RecurringTaskResponse.builder()
+                .recurringGroupId(groupId)
+                .taskCount(taskIds.size())
+                .taskIds(taskIds)
+                .build();
+    }
+
+    /**
+     * 반복 과제 그룹 삭제
+     */
+    public void deleteRecurringTasks(Long mentorId, String recurringGroupId) {
+        List<Task> tasks = taskRepository.findByRecurringGroupId(recurringGroupId);
+
+        if (tasks.isEmpty()) {
+            throw new CustomException(ErrorCode.RECURRING_GROUP_NOT_FOUND);
+        }
+
+        // 멘토-멘티 매핑 검증 (첫 번째 과제의 멘티로 확인)
+        Long menteeId = tasks.get(0).getMentee().getId();
+        if (!menteeInfoRepository.existsByMentorIdAndMenteeId(mentorId, menteeId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        taskRepository.deleteAll(tasks);
+    }
+
+    // === 헬퍼 메서드 ===
+
+    /**
+     * 해당 날짜의 DailyPlan이 없으면 자동 생성
+     */
+    private DailyPlan findOrCreateDailyPlan(User mentee, LocalDate date) {
+        return dailyPlanRepository.findByMenteeIdAndPlanDate(mentee.getId(), date)
+                .orElseGet(() -> {
+                    DailyPlan newPlan = DailyPlan.builder()
+                            .planDate(date)
+                            .mentee(mentee)
+                            .build();
+                    return dailyPlanRepository.save(newPlan);
+                });
+    }
+
+    /**
+     * 과제 수정/삭제 권한 검증
+     * - 고정 과제(멘토 과제): 멘토만 가능
+     * - 비고정 과제(멘티 할 일): 멘티 본인만 가능
+     */
+    private void validateTaskModifyPermission(Task task, Long userId, Role role) {
+        if (task.getIsFixed()) {
+            // 멘토 과제 → 멘토만 수정/삭제 가능
+            if (role != Role.MENTOR) {
+                throw new CustomException(ErrorCode.TASK_NOT_MODIFIABLE);
+            }
+            if (!menteeInfoRepository.existsByMentorIdAndMenteeId(userId, task.getMentee().getId())) {
+                throw new CustomException(ErrorCode.TASK_NOT_MODIFIABLE);
+            }
+        } else {
+            // 멘티 할 일 → 멘티 본인만 수정/삭제 가능
+            if (!task.getMentee().getId().equals(userId)) {
+                throw new CustomException(ErrorCode.TASK_NOT_MODIFIABLE);
+            }
+        }
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
@@ -21,6 +21,14 @@ public enum ErrorCode {
     PLAN_FEEDBACK_NOT_FOUND(404, "플래너 피드백이 존재하지 않습니다."),
     PLAN_FEEDBACK_ALREADY_EXISTS(409, "이미 피드백이 작성되어 있습니다."),
 
+    // Task 관련 오류
+    TASK_NOT_FOUND(404, "존재하지 않는 과제입니다."),
+    TASK_NOT_MODIFIABLE(403, "해당 과제를 수정/삭제할 권한이 없습니다."),
+    TIMER_ALREADY_RUNNING(409, "타이머가 이미 실행 중입니다."),
+    TIMER_NOT_RUNNING(409, "타이머가 실행 중이 아닙니다."),
+    RECURRING_GROUP_NOT_FOUND(404, "반복 과제 그룹을 찾을 수 없습니다."),
+    MENTEE_INFO_NOT_FOUND(404, "멘토-멘티 매핑 정보를 찾을 수 없습니다."),
+
     // 권한 관련 오류
     UNAUTHORIZED_ACCESS(403, "접근 권한이 없습니다.");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,32 @@
 spring:
-  profiles:
-    active: dev
+  datasource:
+    url: jdbc:h2:file:~/testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
 
-springdoc:
-  api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui/index.html
-    disable-swagger-default-url: true
+  cloud:
+    aws:
+      s3:
+        bucket: seolstudy-s3-bucket
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+
+jwt:
+  secret: ${JWT_SECRET:devtokensecretkey12345678901234567890}
+  expiration: 3600000

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,15 @@
+-- 초기 테스트 데이터 (H2 재시작 시 자동 삽입)
+-- MERGE INTO: 이미 존재하면 무시, 없으면 삽입
+
+MERGE INTO users (user_id, username, password, name, nickname, role, is_alarm_enabled)
+KEY (username)
+VALUES (1, 'mentor1', '1234', '멘토1', '멘토닉네임', 'MENTOR', true);
+
+MERGE INTO users (user_id, username, password, name, nickname, role, is_alarm_enabled)
+KEY (username)
+VALUES (2, 'mentee1', '1234', '멘티1', '멘티닉네임', 'MENTEE', true);
+
+-- 멘토-멘티 매핑
+MERGE INTO mentee_info (id, school_name, mentor_id, mentee_id)
+KEY (mentee_id)
+VALUES (1, '테스트고등학교', 1, 2);


### PR DESCRIPTION
## Summary
- Task 도메인 전체 구현 (멘토 과제 출제, 멘티 할 일, 타이머, 반복 과제)
- MenteeInfo 엔티티/레포지토리 추가 (멘토-멘티 매핑)
- PlanResponse에 tasks 목록 포함 + 주간 캘린더 조회 API 추가
- data.sql 초기 테스트 데이터 (mentor1/mentee1)

## 구현된 API
| Method | URI | 설명 |
|--------|-----|------|
| POST | /tasks/{menteeId} | 멘토 과제 출제 |
| POST | /tasks | 멘티 할 일 추가 |
| GET | /tasks/{taskId} | 과제 상세 조회 |
| PUT | /tasks/{taskId} | 과제 수정 |
| DELETE | /tasks/{taskId} | 과제 삭제 |
| PATCH | /mentor/tasks/{taskId}/confirm | 멘토 확인 토글 |
| PATCH | /tasks/{taskId}/timer/start | 타이머 시작 |
| PATCH | /tasks/{taskId}/timer/stop | 타이머 종료 |
| POST | /mentor/mentee/{menteeId}/recurring-tasks | 반복 과제 생성 |
| DELETE | /mentor/recurring-tasks/{recurringGroupId} | 반복 과제 삭제 |
| GET | /plans/calendar/weekly | 주간 캘린더 조회 |

## Test plan
- [x] 멘티 로그인 → POST /tasks 할 일 생성 → DailyPlan 자동 생성 확인
- [x] 멘토 로그인 → POST /tasks/{menteeId} 과제 출제 → 멘티로 수정 시도 시 403
- [x] 타이머 start → stop → actualStudyTime 누적 확인
- [x] 반복 과제 생성 → 개별/그룹 삭제 테스트
- [x] GET /plans/calendar/weekly → 주간 플래너 + tasks 목록 조회

closes [#21]