### PR TITLE
fix: 캘린더 조회 페이지네이션 적용 (#22)

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/PlanController.java
@@ -14,13 +14,15 @@ import com.blaybus.blaybusbe.global.exception.error.ErrorCode;
 import com.blaybus.blaybusbe.global.security.CustomUserDetails;
 import com.blaybus.blaybusbe.domain.plan.service.PlanService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -62,26 +64,28 @@ public class PlanController implements PlanApi {
 
     @Override
     @GetMapping("/calendar")
-    public ResponseEntity<List<CalendarDayResponse>> getCalendar(
+    public ResponseEntity<Page<CalendarDayResponse>> getCalendar(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(required = false) Long menteeId,
             @RequestParam int year,
-            @RequestParam int month
+            @RequestParam int month,
+            @PageableDefault(size = 31, sort = "planDate") Pageable pageable
     ) {
         Long targetMenteeId = menteeId != null ? menteeId : user.getId();
-        return ResponseEntity.ok(planService.getCalendar(targetMenteeId, year, month));
+        return ResponseEntity.ok(planService.getCalendar(targetMenteeId, year, month, pageable));
     }
 
     @Override
     @GetMapping("/calendar/weekly")
-    public ResponseEntity<List<PlanResponse>> getWeeklyCalendar(
+    public ResponseEntity<Page<PlanResponse>> getWeeklyCalendar(
             @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(required = false) Long menteeId,
-            @RequestParam String date
+            @RequestParam String date,
+            @PageableDefault(size = 7, sort = "planDate") Pageable pageable
     ) {
         Long targetMenteeId = menteeId != null ? menteeId : user.getId();
         LocalDate targetDate = LocalDate.parse(date);
-        return ResponseEntity.ok(planService.getWeeklyCalendar(targetMenteeId, targetDate));
+        return ResponseEntity.ok(planService.getWeeklyCalendar(targetMenteeId, targetDate, pageable));
     }
 
     @Override

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/api/PlanApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/api/PlanApi.java
@@ -14,13 +14,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.List;
 
 @Tag(name = "플래너 API", description = "일일 플래너 CRUD 및 멘토 피드백 API")
 public interface PlanApi {
@@ -57,11 +57,12 @@ public interface PlanApi {
             @ApiResponse(responseCode = "200", description = "캘린더 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
     })
-    ResponseEntity<List<CalendarDayResponse>> getCalendar(
+    ResponseEntity<Page<CalendarDayResponse>> getCalendar(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(required = false) Long menteeId,
             @RequestParam int year,
-            @RequestParam int month
+            @RequestParam int month,
+            @Parameter(hidden = true) Pageable pageable
     );
 
     @Operation(summary = "주간 캘린더 조회", description = "특정 날짜가 포함된 주(월~일)의 플래너와 할 일 목록을 조회합니다.")
@@ -69,10 +70,11 @@ public interface PlanApi {
             @ApiResponse(responseCode = "200", description = "주간 캘린더 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
     })
-    ResponseEntity<List<PlanResponse>> getWeeklyCalendar(
+    ResponseEntity<Page<PlanResponse>> getWeeklyCalendar(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
             @RequestParam(required = false) Long menteeId,
-            @Parameter(description = "조회 기준 날짜 (yyyy-MM-dd)") @RequestParam String date
+            @Parameter(description = "조회 기준 날짜 (yyyy-MM-dd)") @RequestParam String date,
+            @Parameter(hidden = true) Pageable pageable
     );
 
     @Operation(summary = "플래너 수정", description = "플래너 메모를 수정합니다.")

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/repository/DailyPlanRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/repository/DailyPlanRepository.java
@@ -1,17 +1,18 @@
 package com.blaybus.blaybusbe.domain.plan.repository;
 
 import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 public interface DailyPlanRepository extends JpaRepository<DailyPlan, Long> {
 
     Optional<DailyPlan> findByMenteeIdAndPlanDate(Long menteeId, LocalDate planDate);
 
-    List<DailyPlan> findByMenteeIdAndPlanDateBetween(Long menteeId, LocalDate startDate, LocalDate endDate);
+    Page<DailyPlan> findByMenteeIdAndPlanDateBetween(Long menteeId, LocalDate startDate, LocalDate endDate, Pageable pageable);
 
     boolean existsByMenteeIdAndPlanDate(Long menteeId, LocalDate planDate);
 }


### PR DESCRIPTION
## Summary
- 월간/주간 캘린더 조회 API의 반환 타입을 List → Page로 변경
- DailyPlanRepository에 Pageable 파라미터 추가
- 월간 기본 size 31, 주간 기본 size 7, planDate 정렬

## Test plan
- [x] GET /plans/calendar?year=2026&month=2 → Page 형식 응답 확인
- [x] GET /plans/calendar/weekly?date=2026-02-05 → Page 형식 응답 확인
- [x] ?page=0&size=5 파라미터로 페이지 제어 확인