### PR TITLE
Feature: 이미지 좌표 기반 피드백 기능 추가

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/FeedbackController.java
@@ -1,0 +1,63 @@
+package com.blaybus.blaybusbe.domain.feedback.controller;
+
+import com.blaybus.blaybusbe.domain.feedback.controller.api.FeedbackApi;
+import com.blaybus.blaybusbe.domain.feedback.dto.request.CreateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.request.UpdateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackResponse;
+import com.blaybus.blaybusbe.domain.feedback.service.FeedbackService;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class FeedbackController implements FeedbackApi {
+
+    private final FeedbackService feedbackService;
+
+    @Override
+    @PostMapping("/images/{imageId}/feedback")
+    public ResponseEntity<FeedbackResponse> createFeedback(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long imageId,
+            @Valid @RequestBody CreateFeedbackRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(feedbackService.createFeedback(user.getId(), imageId, request));
+    }
+
+    @Override
+    @GetMapping("/images/{imageId}/feedback")
+    public ResponseEntity<List<FeedbackResponse>> getFeedbacks(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long imageId
+    ) {
+        return ResponseEntity.ok(feedbackService.getFeedbacksByImageId(imageId));
+    }
+
+    @Override
+    @PutMapping("/feedback/{feedbackId}")
+    public ResponseEntity<FeedbackResponse> updateFeedback(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long feedbackId,
+            @Valid @RequestBody UpdateFeedbackRequest request
+    ) {
+        return ResponseEntity.ok(feedbackService.updateFeedback(user.getId(), feedbackId, request));
+    }
+
+    @Override
+    @DeleteMapping("/feedback/{feedbackId}")
+    public ResponseEntity<Void> deleteFeedback(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long feedbackId
+    ) {
+        feedbackService.deleteFeedback(user.getId(), feedbackId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/api/FeedbackApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/api/FeedbackApi.java
@@ -1,0 +1,62 @@
+package com.blaybus.blaybusbe.domain.feedback.controller.api;
+
+import com.blaybus.blaybusbe.domain.feedback.dto.request.CreateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.request.UpdateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackResponse;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Feedback", description = "이미지 좌표 기반 피드백 API")
+public interface FeedbackApi {
+
+    @Operation(summary = "피드백 작성", description = "이미지에 좌표 기반 피드백을 작성합니다. 멘토만 작성 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "피드백 작성 성공"),
+            @ApiResponse(responseCode = "404", description = "이미지를 찾을 수 없음")
+    })
+    ResponseEntity<FeedbackResponse> createFeedback(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "이미지 ID") Long imageId,
+            CreateFeedbackRequest request
+    );
+
+    @Operation(summary = "이미지별 피드백 목록 조회", description = "해당 이미지에 작성된 피드백 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "이미지를 찾을 수 없음")
+    })
+    ResponseEntity<List<FeedbackResponse>> getFeedbacks(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "이미지 ID") Long imageId
+    );
+
+    @Operation(summary = "피드백 수정", description = "피드백을 수정합니다. 본인이 작성한 피드백만 수정 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "피드백을 찾을 수 없음")
+    })
+    ResponseEntity<FeedbackResponse> updateFeedback(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "피드백 ID") Long feedbackId,
+            UpdateFeedbackRequest request
+    );
+
+    @Operation(summary = "피드백 삭제", description = "피드백을 삭제합니다. 본인이 작성한 피드백만 삭제 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "피드백을 찾을 수 없음")
+    })
+    ResponseEntity<Void> deleteFeedback(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "피드백 ID") Long feedbackId
+    );
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/request/CreateFeedbackRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/request/CreateFeedbackRequest.java
@@ -1,0 +1,29 @@
+package com.blaybus.blaybusbe.domain.feedback.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+public class CreateFeedbackRequest {
+
+    @Schema(description = "피드백 내용 (<강조>...</강조> 태그로 강조 가능)", example = "이 부분에서 <강조>공식 적용이 잘못됐어요.</강조>")
+    @NotBlank(message = "피드백 내용은 필수입니다.")
+    private String content;
+
+    @Schema(description = "첨부 이미지 URL (선택)", example = "https://s3-bucket.../feedback/uuid.jpg")
+    private String imageUrl;
+
+    @Schema(description = "X 좌표 (0.0~1.0 비율)", example = "0.35")
+    @NotNull(message = "X 좌표는 필수입니다.")
+    private Float xPos;
+
+    @Schema(description = "Y 좌표 (0.0~1.0 비율)", example = "0.72")
+    @NotNull(message = "Y 좌표는 필수입니다.")
+    private Float yPos;
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/request/UpdateFeedbackRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/request/UpdateFeedbackRequest.java
@@ -1,0 +1,29 @@
+package com.blaybus.blaybusbe.domain.feedback.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+public class UpdateFeedbackRequest {
+
+    @Schema(description = "피드백 내용 (<강조>...</강조> 태그로 강조 가능)", example = "수정된 피드백 내용입니다.")
+    @NotBlank(message = "피드백 내용은 필수입니다.")
+    private String content;
+
+    @Schema(description = "첨부 이미지 URL (선택)", example = "https://s3-bucket.../feedback/uuid.jpg")
+    private String imageUrl;
+
+    @Schema(description = "X 좌표 (0.0~1.0 비율)", example = "0.35")
+    @NotNull(message = "X 좌표는 필수입니다.")
+    private Float xPos;
+
+    @Schema(description = "Y 좌표 (0.0~1.0 비율)", example = "0.72")
+    @NotNull(message = "Y 좌표는 필수입니다.")
+    private Float yPos;
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/response/FeedbackResponse.java
@@ -1,0 +1,34 @@
+package com.blaybus.blaybusbe.domain.feedback.dto.response;
+
+import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FeedbackResponse {
+
+    private Long id;
+    private String content;
+    private String imageUrl;
+    private Float xPos;
+    private Float yPos;
+    private String mentorName;
+    private Integer commentCount;
+    private LocalDateTime createdAt;
+
+    public static FeedbackResponse from(TaskFeedback feedback, int commentCount) {
+        return FeedbackResponse.builder()
+                .id(feedback.getId())
+                .content(feedback.getContent())
+                .imageUrl(feedback.getImageUrl())
+                .xPos(feedback.getXPos())
+                .yPos(feedback.getYPos())
+                .mentorName(feedback.getMentor().getName())
+                .commentCount(commentCount)
+                .createdAt(feedback.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/entity/TaskFeedback.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/entity/TaskFeedback.java
@@ -1,0 +1,65 @@
+package com.blaybus.blaybusbe.domain.feedback.entity;
+
+import com.blaybus.blaybusbe.domain.submission.entity.SubmissionImage;
+import com.blaybus.blaybusbe.domain.task.entity.Task;
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.global.common.BaseCreateEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "task_feedbacks")
+public class TaskFeedback extends BaseCreateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private String imageUrl;
+
+    @Column(name = "x_pos", nullable = false)
+    private Float xPos;
+
+    @Column(name = "y_pos", nullable = false)
+    private Float yPos;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id", nullable = false)
+    private User mentor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id", nullable = false)
+    private SubmissionImage image;
+
+    @Builder
+    public TaskFeedback(String content, String imageUrl, Float xPos, Float yPos,
+                        Task task, User mentor, SubmissionImage image) {
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.xPos = xPos;
+        this.yPos = yPos;
+        this.task = task;
+        this.mentor = mentor;
+        this.image = image;
+    }
+
+    public void update(String content, String imageUrl, Float xPos, Float yPos) {
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.xPos = xPos;
+        this.yPos = yPos;
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/repository/TaskFeedbackRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/repository/TaskFeedbackRepository.java
@@ -1,0 +1,17 @@
+package com.blaybus.blaybusbe.domain.feedback.repository;
+
+import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TaskFeedbackRepository extends JpaRepository<TaskFeedback, Long> {
+
+    @Query("SELECT f FROM TaskFeedback f JOIN FETCH f.mentor WHERE f.image.id = :imageId ORDER BY f.createdAt DESC")
+    List<TaskFeedback> findByImageIdWithMentor(@Param("imageId") Long imageId);
+
+    @Query("SELECT COUNT(f) FROM TaskFeedback f WHERE f.image.id = :imageId")
+    int countByImageId(@Param("imageId") Long imageId);
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
@@ -1,0 +1,100 @@
+package com.blaybus.blaybusbe.domain.feedback.service;
+
+import com.blaybus.blaybusbe.domain.feedback.dto.request.CreateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.request.UpdateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackResponse;
+import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import com.blaybus.blaybusbe.domain.feedback.repository.TaskFeedbackRepository;
+import com.blaybus.blaybusbe.domain.submission.entity.SubmissionImage;
+import com.blaybus.blaybusbe.domain.submission.repository.SubmissionImageRepository;
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.domain.user.repository.UserRepository;
+import com.blaybus.blaybusbe.global.exception.CustomException;
+import com.blaybus.blaybusbe.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FeedbackService {
+
+    private final TaskFeedbackRepository feedbackRepository;
+    private final SubmissionImageRepository imageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FeedbackResponse createFeedback(Long mentorId, Long imageId, CreateFeedbackRequest request) {
+        // 멘토 조회
+        User mentor = userRepository.findById(mentorId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미지 조회
+        SubmissionImage image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.IMAGE_NOT_FOUND));
+
+        // 피드백 생성
+        TaskFeedback feedback = TaskFeedback.builder()
+                .content(request.getContent())
+                .imageUrl(request.getImageUrl())
+                .xPos(request.getXPos())
+                .yPos(request.getYPos())
+                .task(image.getSubmission().getTask())
+                .mentor(mentor)
+                .image(image)
+                .build();
+
+        feedbackRepository.save(feedback);
+
+        return FeedbackResponse.from(feedback, 0);
+    }
+
+    public List<FeedbackResponse> getFeedbacksByImageId(Long imageId) {
+        // 이미지 존재 확인
+        if (!imageRepository.existsById(imageId)) {
+            throw new CustomException(ErrorCode.IMAGE_NOT_FOUND);
+        }
+
+        List<TaskFeedback> feedbacks = feedbackRepository.findByImageIdWithMentor(imageId);
+
+        return feedbacks.stream()
+                .map(feedback -> FeedbackResponse.from(feedback, 0)) // TODO: 댓글 수 조회 추가
+                .toList();
+    }
+
+    @Transactional
+    public FeedbackResponse updateFeedback(Long mentorId, Long feedbackId, UpdateFeedbackRequest request) {
+        TaskFeedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        // 본인 피드백인지 확인
+        if (!feedback.getMentor().getId().equals(mentorId)) {
+            throw new CustomException(ErrorCode.FEEDBACK_NOT_OWNER);
+        }
+
+        feedback.update(
+                request.getContent(),
+                request.getImageUrl(),
+                request.getXPos(),
+                request.getYPos()
+        );
+
+        return FeedbackResponse.from(feedback, 0);
+    }
+
+    @Transactional
+    public void deleteFeedback(Long mentorId, Long feedbackId) {
+        TaskFeedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        // 본인 피드백인지 확인
+        if (!feedback.getMentor().getId().equals(mentorId)) {
+            throw new CustomException(ErrorCode.FEEDBACK_NOT_OWNER);
+        }
+
+        feedbackRepository.delete(feedback);
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/submission/dto/response/SubmissionImageResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/submission/dto/response/SubmissionImageResponse.java
@@ -1,0 +1,20 @@
+package com.blaybus.blaybusbe.domain.submission.dto.response;
+
+import com.blaybus.blaybusbe.domain.submission.entity.SubmissionImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubmissionImageResponse {
+
+    private Long id;
+    private String imageUrl;
+
+    public static SubmissionImageResponse from(SubmissionImage image) {
+        return SubmissionImageResponse.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/submission/dto/response/SubmissionResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/submission/dto/response/SubmissionResponse.java
@@ -1,6 +1,5 @@
 package com.blaybus.blaybusbe.domain.submission.dto.response;
 
-import com.blaybus.blaybusbe.domain.submission.entity.SubmissionImage;
 import com.blaybus.blaybusbe.domain.submission.entity.TaskSubmission;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,19 +12,19 @@ import java.util.List;
 public class SubmissionResponse {
 
     private Long id;
-    private List<String> fileUrls;
+    private List<SubmissionImageResponse> images;
     private String menteeComment;
     private LocalDateTime createdAt;
     private String menteeName;
 
     public static SubmissionResponse from(TaskSubmission submission) {
-        List<String> fileUrls = submission.getImages().stream()
-                .map(SubmissionImage::getImageUrl)
+        List<SubmissionImageResponse> images = submission.getImages().stream()
+                .map(SubmissionImageResponse::from)
                 .toList();
 
         return SubmissionResponse.builder()
                 .id(submission.getId())
-                .fileUrls(fileUrls)
+                .images(images)
                 .menteeComment(submission.getMenteeComment())
                 .createdAt(submission.getCreatedAt())
                 .menteeName(submission.getTask().getMentee().getName())

--- a/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
@@ -44,6 +44,11 @@ public enum ErrorCode {
     SUBMISSION_ALREADY_EXISTS(409, "이미 제출물이 존재합니다."),
     SUBMISSION_NOT_OWNER(403, "본인의 제출물만 삭제할 수 있습니다."),
 
+    // 피드백 관련 오류
+    FEEDBACK_NOT_FOUND(404, "피드백이 존재하지 않습니다."),
+    FEEDBACK_NOT_OWNER(403, "본인이 작성한 피드백만 수정/삭제할 수 있습니다."),
+    IMAGE_NOT_FOUND(404, "이미지가 존재하지 않습니다."),
+
     // 권한 관련 오류
     UNAUTHORIZED_ACCESS(403, "접근 권한이 없습니다.");
 


### PR DESCRIPTION
## Summary
- 멘토가 멘티의 과제 제출 이미지에 좌표(xPos, yPos)를 찍어 피드백을 작성하는 기능 구현
- 제출물 조회 시 각 이미지의 `imageId`를 함께 반환하도록 개선 (피드백 작성 시 imageId 필요)

## Changes
### 신규 - Feedback 도메인 (8파일)
- `FeedbackController` / `FeedbackApi` — 피드백 CRUD API (POST/GET/PUT/DELETE)
- `CreateFeedbackRequest` / `UpdateFeedbackRequest` — 요청 DTO (@Schema, @JsonAutoDetect 적용)
- `FeedbackResponse` — 응답 DTO
- `TaskFeedback` — 엔티티 (content, imageUrl, xPos, yPos, mentor_id, image_id)
- `TaskFeedbackRepository` — JPA Repository
- `FeedbackService` — 비즈니스 로직

### 수정 - Submission 응답 개선
- `SubmissionResponse`: `List<String> fileUrls` → `List<SubmissionImageResponse> images`
- `SubmissionImageResponse` 신규 추가: 각 이미지의 `id` + `imageUrl` 반환

### 수정 - ErrorCode
- `FEEDBACK_NOT_FOUND` (404), `FEEDBACK_NOT_OWNER` (403), `IMAGE_NOT_FOUND` (404) 추가

## API Endpoints
| Method | URI | 설명 |
|--------|-----|------|
| POST | `/images/{imageId}/feedback` | 이미지 좌표 피드백 작성 (멘토) |
| GET | `/images/{imageId}/feedback` | 이미지별 피드백 목록 조회 |
| PUT | `/feedback/{feedbackId}` | 피드백 수정 (본인만) |
| DELETE | `/feedback/{feedbackId}` | 피드백 삭제 (본인만) |

## Test plan
- [x] 멘토 로그인 → 과제 제출물 조회 시 imageId 반환 확인
- [x] imageId로 피드백 작성 (xPos, yPos 좌표 포함) 정상 동작 확인
- [x] 피드백 조회/수정/삭제 정상 동작 확인
- [x] 본인 외 피드백 수정/삭제 시 403 에러 확인

close #37 