### PR TITLE
Feature: 피드백 댓글 기능 추가

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/controller/CommentController.java
@@ -1,0 +1,63 @@
+package com.blaybus.blaybusbe.domain.comment.controller;
+
+import com.blaybus.blaybusbe.domain.comment.controller.api.CommentApi;
+import com.blaybus.blaybusbe.domain.comment.dto.request.CreateCommentRequest;
+import com.blaybus.blaybusbe.domain.comment.dto.request.UpdateCommentRequest;
+import com.blaybus.blaybusbe.domain.comment.dto.response.CommentResponse;
+import com.blaybus.blaybusbe.domain.comment.service.CommentService;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController implements CommentApi {
+
+    private final CommentService commentService;
+
+    @Override
+    @PostMapping("/feedback/{feedbackId}/comments")
+    public ResponseEntity<CommentResponse> createComment(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long feedbackId,
+            @Valid @RequestBody CreateCommentRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(commentService.createComment(user.getId(), feedbackId, request));
+    }
+
+    @Override
+    @GetMapping("/feedback/{feedbackId}/comments")
+    public ResponseEntity<List<CommentResponse>> getComments(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long feedbackId
+    ) {
+        return ResponseEntity.ok(commentService.getComments(feedbackId));
+    }
+
+    @Override
+    @PutMapping("/feedback/comments/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateCommentRequest request
+    ) {
+        return ResponseEntity.ok(commentService.updateComment(user.getId(), commentId, request));
+    }
+
+    @Override
+    @DeleteMapping("/feedback/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(user.getId(), commentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/controller/api/CommentApi.java
@@ -1,0 +1,62 @@
+package com.blaybus.blaybusbe.domain.comment.controller.api;
+
+import com.blaybus.blaybusbe.domain.comment.dto.request.CreateCommentRequest;
+import com.blaybus.blaybusbe.domain.comment.dto.request.UpdateCommentRequest;
+import com.blaybus.blaybusbe.domain.comment.dto.response.CommentResponse;
+import com.blaybus.blaybusbe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Comment", description = "피드백 댓글 API")
+public interface CommentApi {
+
+    @Operation(summary = "댓글 작성", description = "피드백에 텍스트 댓글을 작성합니다. 멘토/멘티 모두 작성 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "댓글 작성 성공"),
+            @ApiResponse(responseCode = "404", description = "피드백을 찾을 수 없음")
+    })
+    ResponseEntity<CommentResponse> createComment(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "피드백 ID") Long feedbackId,
+            CreateCommentRequest request
+    );
+
+    @Operation(summary = "댓글 목록 조회", description = "피드백에 작성된 댓글 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "피드백을 찾을 수 없음")
+    })
+    ResponseEntity<List<CommentResponse>> getComments(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "피드백 ID") Long feedbackId
+    );
+
+    @Operation(summary = "댓글 수정", description = "댓글을 수정합니다. 본인이 작성한 댓글만 수정 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음")
+    })
+    ResponseEntity<CommentResponse> updateComment(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "댓글 ID") Long commentId,
+            UpdateCommentRequest request
+    );
+
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다. 본인이 작성한 댓글만 삭제 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음")
+    })
+    ResponseEntity<Void> deleteComment(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "댓글 ID") Long commentId
+    );
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/request/CreateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.blaybus.blaybusbe.domain.comment.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+public class CreateCommentRequest {
+
+    @Schema(description = "댓글 내용", example = "이 부분 다시 풀어봤는데 맞나요?")
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String comment;
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,17 @@
+package com.blaybus.blaybusbe.domain.comment.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+public class UpdateCommentRequest {
+
+    @Schema(description = "수정할 댓글 내용", example = "수정된 댓글 내용입니다.")
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String comment;
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,29 @@
+package com.blaybus.blaybusbe.domain.comment.dto.response;
+
+import com.blaybus.blaybusbe.domain.comment.entity.Answer;
+import com.blaybus.blaybusbe.domain.user.enums.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponse {
+
+    private Long id;
+    private String comment;
+    private String authorName;
+    private Role role;
+    private LocalDateTime createdAt;
+
+    public static CommentResponse from(Answer answer) {
+        return CommentResponse.builder()
+                .id(answer.getId())
+                .comment(answer.getComment())
+                .authorName(answer.getUser().getName())
+                .role(answer.getUser().getRole())
+                .createdAt(answer.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/entity/Answer.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/entity/Answer.java
@@ -1,0 +1,42 @@
+package com.blaybus.blaybusbe.domain.comment.entity;
+
+import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "answer")
+public class Answer extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feedback_id", nullable = false)
+    private TaskFeedback feedback;
+
+    @Builder
+    public Answer(String comment, User user, TaskFeedback feedback) {
+        this.comment = comment;
+        this.user = user;
+        this.feedback = feedback;
+    }
+
+    public void update(String comment) {
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/repository/AnswerRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/repository/AnswerRepository.java
@@ -1,0 +1,16 @@
+package com.blaybus.blaybusbe.domain.comment.repository;
+
+import com.blaybus.blaybusbe.domain.comment.entity.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+    @Query("SELECT a FROM Answer a JOIN FETCH a.user WHERE a.feedback.id = :feedbackId ORDER BY a.createdAt ASC")
+    List<Answer> findByFeedbackIdOrderByCreatedAtAsc(@Param("feedbackId") Long feedbackId);
+
+    int countByFeedbackId(Long feedbackId);
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/service/CommentService.java
@@ -1,0 +1,91 @@
+package com.blaybus.blaybusbe.domain.comment.service;
+
+import com.blaybus.blaybusbe.domain.comment.dto.request.CreateCommentRequest;
+import com.blaybus.blaybusbe.domain.comment.dto.request.UpdateCommentRequest;
+import com.blaybus.blaybusbe.domain.comment.dto.response.CommentResponse;
+import com.blaybus.blaybusbe.domain.comment.entity.Answer;
+import com.blaybus.blaybusbe.domain.comment.repository.AnswerRepository;
+import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import com.blaybus.blaybusbe.domain.feedback.repository.TaskFeedbackRepository;
+import com.blaybus.blaybusbe.domain.user.entity.User;
+import com.blaybus.blaybusbe.domain.user.repository.UserRepository;
+import com.blaybus.blaybusbe.global.exception.CustomException;
+import com.blaybus.blaybusbe.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final AnswerRepository answerRepository;
+    private final TaskFeedbackRepository feedbackRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long userId, Long feedbackId, CreateCommentRequest request) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 피드백 조회
+        TaskFeedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        // 댓글 생성
+        Answer answer = Answer.builder()
+                .comment(request.getComment())
+                .user(user)
+                .feedback(feedback)
+                .build();
+
+        answerRepository.save(answer);
+
+        return CommentResponse.from(answer);
+    }
+
+    public List<CommentResponse> getComments(Long feedbackId) {
+        // 피드백 존재 확인
+        if (!feedbackRepository.existsById(feedbackId)) {
+            throw new CustomException(ErrorCode.FEEDBACK_NOT_FOUND);
+        }
+
+        List<Answer> answers = answerRepository.findByFeedbackIdOrderByCreatedAtAsc(feedbackId);
+
+        return answers.stream()
+                .map(CommentResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long userId, Long commentId, UpdateCommentRequest request) {
+        Answer answer = answerRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 본인 댓글인지 확인
+        if (!answer.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMENT_NOT_OWNER);
+        }
+
+        answer.update(request.getComment());
+
+        return CommentResponse.from(answer);
+    }
+
+    @Transactional
+    public void deleteComment(Long userId, Long commentId) {
+        Answer answer = answerRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 본인 댓글인지 확인
+        if (!answer.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.COMMENT_NOT_OWNER);
+        }
+
+        answerRepository.delete(answer);
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
@@ -1,5 +1,6 @@
 package com.blaybus.blaybusbe.domain.feedback.service;
 
+import com.blaybus.blaybusbe.domain.comment.repository.AnswerRepository;
 import com.blaybus.blaybusbe.domain.feedback.dto.request.CreateFeedbackRequest;
 import com.blaybus.blaybusbe.domain.feedback.dto.request.UpdateFeedbackRequest;
 import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackResponse;
@@ -25,6 +26,7 @@ public class FeedbackService {
     private final TaskFeedbackRepository feedbackRepository;
     private final SubmissionImageRepository imageRepository;
     private final UserRepository userRepository;
+    private final AnswerRepository answerRepository;
 
     @Transactional
     public FeedbackResponse createFeedback(Long mentorId, Long imageId, CreateFeedbackRequest request) {
@@ -49,7 +51,7 @@ public class FeedbackService {
 
         feedbackRepository.save(feedback);
 
-        return FeedbackResponse.from(feedback, 0);
+        return FeedbackResponse.from(feedback, answerRepository.countByFeedbackId(feedback.getId()));
     }
 
     public List<FeedbackResponse> getFeedbacksByImageId(Long imageId) {
@@ -61,7 +63,7 @@ public class FeedbackService {
         List<TaskFeedback> feedbacks = feedbackRepository.findByImageIdWithMentor(imageId);
 
         return feedbacks.stream()
-                .map(feedback -> FeedbackResponse.from(feedback, 0)) // TODO: 댓글 수 조회 추가
+                .map(feedback -> FeedbackResponse.from(feedback, answerRepository.countByFeedbackId(feedback.getId())))
                 .toList();
     }
 
@@ -82,7 +84,7 @@ public class FeedbackService {
                 request.getYPos()
         );
 
-        return FeedbackResponse.from(feedback, 0);
+        return FeedbackResponse.from(feedback, answerRepository.countByFeedbackId(feedbackId));
     }
 
     @Transactional

--- a/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
@@ -49,6 +49,10 @@ public enum ErrorCode {
     FEEDBACK_NOT_OWNER(403, "본인이 작성한 피드백만 수정/삭제할 수 있습니다."),
     IMAGE_NOT_FOUND(404, "이미지가 존재하지 않습니다."),
 
+    // 댓글 관련 오류
+    COMMENT_NOT_FOUND(404, "댓글이 존재하지 않습니다."),
+    COMMENT_NOT_OWNER(403, "본인이 작성한 댓글만 수정/삭제할 수 있습니다."),
+
     // 권한 관련 오류
     UNAUTHORIZED_ACCESS(403, "접근 권한이 없습니다.");
 


### PR DESCRIPTION
## Summary
- 이미지 좌표 피드백에 멘토/멘티가 텍스트 댓글을 남기는 기능 구현
- 댓글 CRUD API 4개 (작성, 조회, 수정, 삭제)
- 피드백 조회 시 commentCount를 실제 댓글 수로 반영

## 변경 사항
- **신규 파일 (8개)**: Answer 엔티티, AnswerRepository, CreateCommentRequest, UpdateCommentRequest, CommentResponse, CommentApi, CommentController, CommentService
- **수정 파일 (2개)**: ErrorCode (COMMENT_NOT_FOUND, COMMENT_NOT_OWNER 추가), FeedbackService (commentCount 실제 조회)

## API 엔드포인트
| Method | URI | 설명 |
|--------|-----|------|
| POST | `/feedback/{feedbackId}/comments` | 댓글 작성 |
| GET | `/feedback/{feedbackId}/comments` | 댓글 목록 조회 |
| PUT | `/feedback/comments/{commentId}` | 댓글 수정 (본인만) |
| DELETE | `/feedback/comments/{commentId}` | 댓글 삭제 (본인만) |

## Test plan
- [x] 서버 실행 후 Swagger에서 4개 API 테스트
- [x] 멘토/멘티 각각 로그인하여 댓글 작성 → 조회 시 authorName, role 정상 표시 확인
- [x] 타인 댓글 수정/삭제 시 403 에러 확인
- [x] 피드백 조회 시 commentCount 실제 댓글 수 반영 확인

close #39 