### PR TITLE
Feature: 멘티 줌 미팅 피드백 목록 및 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/controller/ZoomFeedbackController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/controller/ZoomFeedbackController.java
@@ -24,7 +24,7 @@ public class ZoomFeedbackController implements ZoomFeedbackApi {
     /**
      * 멘토가 줌 피드백을 작성합니다.
      *
-     * @param user 토큰 추출
+     * @param user     토큰 추출
      * @param menteeId 멘토 id
      * @param request
      */
@@ -76,5 +76,23 @@ public class ZoomFeedbackController implements ZoomFeedbackApi {
             @RequestBody CreateZoomFeedbackRequest request
     ) {
         return ResponseEntity.ok(zoomFeedbackService.updateZoomFeedback(user.getId(), feedbackId, request));
+    }
+
+    @Override
+    @GetMapping("/mentee/list")
+    public ResponseEntity<Page<ZoomFeedbackListResponse>> getMenteeZoomFeedbackList(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @ParameterObject Pageable pageable
+    ) {
+        return ResponseEntity.ok(zoomFeedbackService.findMenteeZoomFeedbackList(user.getId(), pageable));
+    }
+
+    @Override
+    @GetMapping("/mentee/zoom-feedback/{feedbackId}")
+    public ResponseEntity<ZoomFeedbackResponse> getMenteeZoomFeedback(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long feedbackId
+    ) {
+        return ResponseEntity.ok(zoomFeedbackService.findMenteeZoomFeedback(user.getId(), feedbackId));
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/controller/api/ZoomFeedbackApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/controller/api/ZoomFeedbackApi.java
@@ -34,7 +34,7 @@ public interface ZoomFeedbackApi {
             CreateZoomFeedbackRequest request
     );
 
-    @Operation(summary = "줌 피드백 상세 조회", description = "작성된 줌 피드백의 상세 내용을 조회합니다.(멘토만 조회 가능)")
+    @Operation(summary = "[멘토] 줌 피드백 상세 조회", description = "작성된 줌 피드백의 상세 내용을 조회합니다.(멘토만 조회 가능)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "줌 조회 성공",
                     content = @Content(schema = @Schema(implementation = ZoomFeedbackResponse.class))),
@@ -47,7 +47,7 @@ public interface ZoomFeedbackApi {
             @PathVariable Long feedbackId
     );
 
-    @Operation(summary = "줌 피드백 목록 조회", description = "멘토가 작성한 줌 피드백 목록을 최신순으로 조회합니다.")
+    @Operation(summary = "[멘토] 줌 피드백 목록 조회", description = "멘토가 작성한 줌 피드백 목록을 최신순으로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "줌 피드백 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = ZoomFeedbackListResponse.class))),
@@ -77,5 +77,30 @@ public interface ZoomFeedbackApi {
             @Parameter(description = "피드백 id", required = true , example = "1")
             Long feedbackId,
             CreateZoomFeedbackRequest request
+    );
+
+    @Operation(summary = "[멘티] 줌 피드백 목록 조회", description = "로그인한 멘티가 받은 줌 피드백 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "줌 피드백 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ZoomFeedbackListResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자", content = @Content),
+    })
+    ResponseEntity<Page<ZoomFeedbackListResponse>> getMenteeZoomFeedbackList(
+            @Parameter(hidden = true) CustomUserDetails user,
+            Pageable pageable
+    );
+
+    @Operation(summary = "[멘티] 줌 피드백 상세 조회", description = "작성된 줌 피드백의 상세 내용을 조회합니다.(멘티만 조회 가능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "줌 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ZoomFeedbackResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없는 사용자", content = @Content),
+    })
+    ResponseEntity<ZoomFeedbackResponse> getMenteeZoomFeedback(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "피드백 id", required = true , example = "1")
+            @PathVariable Long feedbackId
     );
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/repository/ZoomFeedbackRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/repository/ZoomFeedbackRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ZoomFeedbackRepository extends JpaRepository<ZoomFeedback, Long> {
 
-    // 줌 미팅 피드백 목록 조회
+    // [맨토] 줌 미팅 피드백 목록 조회
     @Query("SELECT z FROM ZoomFeedback z " +
             "JOIN FETCH z.menteeInfo mi " +
             "JOIN FETCH mi.mentee " +
@@ -18,4 +18,11 @@ public interface ZoomFeedbackRepository extends JpaRepository<ZoomFeedback, Long
             @Param("mentorId") Long mentorId,
             @Param("menteeId") Long menteeId,
             Pageable pageable);
+
+    // [멘티] 줌 미팅 피드백 목록 조회
+    @Query("SELECT z FROM ZoomFeedback z " +
+            "JOIN FETCH z.menteeInfo mi " +
+            "JOIN FETCH mi.mentor " +
+            "WHERE mi.mentee.id = :menteeId")
+    Page<ZoomFeedback> findAllByMenteeId(@Param("menteeId") Long menteeId, Pageable pageable);
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/service/ZoomFeedbackService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/service/ZoomFeedbackService.java
@@ -133,4 +133,36 @@ public class ZoomFeedbackService {
 
         return ZoomFeedbackResponse.from(feedback);
     }
+
+    /**
+     * [멘티] 줌 피드백 목록 조회 함수.
+     *
+     * @param menteeId 멘티 id
+     * @param pageable 페이지네이션
+     */
+    @Transactional(readOnly = true)
+    public Page<ZoomFeedbackListResponse> findMenteeZoomFeedbackList(Long menteeId, Pageable pageable) {
+
+        return zoomFeedbackRepository.findAllByMenteeId(menteeId, pageable)
+                .map(ZoomFeedbackListResponse::from);
+    }
+
+    /**
+     * 멘티가 본인의 줌 피드백을 상세 조회하는 함수.
+     *
+     * @param userId 조회한 사용자 id
+     * @param feedbackId 피드백 id
+     */
+    @Transactional(readOnly = true)
+    public ZoomFeedbackResponse findMenteeZoomFeedback(Long userId, Long feedbackId) {
+        ZoomFeedback feedback = zoomFeedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        // 줌 피드백에 관계 없는 사용자인지 검증
+        if(!feedback.getMenteeInfo().getMentee().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return ZoomFeedbackResponse.from(feedback);
+    }
 }


### PR DESCRIPTION
### 주요 변경 사항

#### 1. 멘티 전용 줌 피드백 목록 조회 구현
* **구현 내용**: 로그인한 멘티가 본인이 받은 모든 줌 미팅 피드백을 최신순으로 확인할 수 있는 기능을 추가했습니다.
* **성능 최적화**: `JOIN FETCH`를 활용하여 담당 멘토의 정보를 한 번의 쿼리로 가져옴으로써 N+1 문제를 방지하고 조회 속도를 개선했습니다.

#### 2. 멘티 전용 상세 조회 및 권한 검증 로직 추가
* **조회 로직**: 멘티가 특정 피드백 상세 페이지에 접근할 때, 해당 피드백이 본인에게 배정된 것인지 확인하는 `findMenteeZoomFeedback` 기능을 구현했습니다.
* **보안 강화**: 멘티 본인의 `MenteeInfo`와 피드백에 저장된 정보를 대조하여 타인의 상담 기록에 접근하는 것을 원천 차단했습니다.

#### 3. 서비스 레이어 리팩토링
* **코드 정제**: 기존의 공통 조회 로직(`getZoomFeedback`)과 멘티 전용 로직을 분리하여 각 역할에 맞는 최적의 검증 방식을 적용했습니다.

### 기술적 의사결정
* **Fetch Join 활용**: `ZoomFeedback` → `MenteeInfo` → `Mentor`로 이어지는 관계를 적극 활용하여 DB 부하를 최소화했습니다.
* **객체 기반 검증**: ID 단순 비교를 넘어 엔티티 간의 연관 관계를 바탕으로 권한을 확인하여 데이터 무결성을 높였습니다.

close #52 