### PR TITLE
Feature: 보완점 목록 조회 시 과목별 필터 추가

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/controller/WeaknessController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/controller/WeaknessController.java
@@ -3,6 +3,7 @@ package com.blaybus.blaybusbe.domain.weakness.controller;
 import com.blaybus.blaybusbe.domain.weakness.controller.api.WeaknessApi;
 import com.blaybus.blaybusbe.domain.weakness.dto.request.RequestWeaknessDto;
 import com.blaybus.blaybusbe.domain.weakness.dto.response.ResponseWeaknessDto;
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
 import com.blaybus.blaybusbe.domain.weakness.service.WeaknessService;
 import com.blaybus.blaybusbe.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -52,9 +53,11 @@ public class WeaknessController implements WeaknessApi {
     public ResponseEntity<Page<ResponseWeaknessDto>> getMenteeWeaknesses(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long menteeId,
+
+            @RequestParam(required = false) Subject subject,
             @ParameterObject Pageable pageable
     ) {
-        return ResponseEntity.ok(weaknessService.getMenteeWeaknesses(user.getId(), menteeId, pageable));
+        return ResponseEntity.ok(weaknessService.getMenteeWeaknesses(user.getId(), menteeId, subject, pageable));
     }
 
     /**
@@ -69,9 +72,10 @@ public class WeaknessController implements WeaknessApi {
             @AuthenticationPrincipal
             CustomUserDetails user,
 
+            @RequestParam(required = false) Subject subject,
             @ParameterObject Pageable pageable
     ) {
-        return ResponseEntity.ok(weaknessService.getMyWeaknesses(user.getId(), pageable));
+        return ResponseEntity.ok(weaknessService.getMyWeaknesses(user.getId(), subject, pageable));
     }
 
     /**

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/controller/api/WeaknessApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/controller/api/WeaknessApi.java
@@ -3,6 +3,7 @@ package com.blaybus.blaybusbe.domain.weakness.controller.api;
 import com.blaybus.blaybusbe.domain.mentoring.dto.response.ResponseMyMentorDto;
 import com.blaybus.blaybusbe.domain.weakness.dto.request.RequestWeaknessDto;
 import com.blaybus.blaybusbe.domain.weakness.dto.response.ResponseWeaknessDto;
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
 import com.blaybus.blaybusbe.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -37,7 +38,7 @@ public interface WeaknessApi {
             @RequestBody RequestWeaknessDto request
     );
 
-    @Operation(summary = "멘티의 보완점 목록 조회", description = "특정 멘티에게 등록된 보완점 리스트를 조회합니다.")
+    @Operation(summary = "멘티의 보완점 목록 조회", description = "특정 멘티에게 등록된 보완점 리스트를 과목별로(과목 미입력 시 전체) 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "멘티 보완점 목록 조회 성공",
                     content = @Content(schema = @Schema(implementation = ResponseWeaknessDto.class))),
@@ -51,6 +52,9 @@ public interface WeaknessApi {
 
             @Parameter(description = "멘티 id", required = true , example = "1")
             @PathVariable Long menteeId,
+
+            @Parameter(description = "과목 (KOREAN, MATH, ENGLISH)", example = "KOREAN")
+            Subject subject,
 
             @ParameterObject Pageable pageable
     );
@@ -67,6 +71,8 @@ public interface WeaknessApi {
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails user,
 
+            @Parameter(description = "과목 (KOREAN, MATH, ENGLISH)", example = "KOREAN")
+            Subject subject,
             @ParameterObject Pageable pageable
     );
 

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/dto/request/RequestWeaknessDto.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/dto/request/RequestWeaknessDto.java
@@ -1,14 +1,21 @@
 package com.blaybus.blaybusbe.domain.weakness.dto.request;
 
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record RequestWeaknessDto(
+        @Schema(description = "보완점 제목", example = "자료구조 보완")
         @NotBlank
         String title,
 
         @NotNull(message = "멘티 식별자가 필요합니다.")
         Long menteeId,
+
+        @Schema(description = "과목", example = "KOREAN")
+        @NotNull
+        Subject subject,
 
         @NotNull
         Long contentId

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/dto/response/ResponseWeaknessDto.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/dto/response/ResponseWeaknessDto.java
@@ -1,10 +1,12 @@
 package com.blaybus.blaybusbe.domain.weakness.dto.response;
 
 import com.blaybus.blaybusbe.domain.weakness.entitiy.Weakness;
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
 
 public record ResponseWeaknessDto(
         Long id,
         String title,
+        Subject subject,
         Long contentId,
         String contentTitle,    // 학습 자료 제목
         String contentUrl       // 학습 자료 PDF URL
@@ -13,6 +15,7 @@ public record ResponseWeaknessDto(
         return new ResponseWeaknessDto(
                 entity.getId(),
                 entity.getTitle(),
+                entity.getSubject(),
                 entity.getStudyContent() != null ? entity.getStudyContent().getId() : null,
                 entity.getStudyContent() != null ? entity.getStudyContent().getTitle() : null,
                 entity.getStudyContent() != null ? entity.getStudyContent().getContentUrl() : null

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/entitiy/Weakness.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/entitiy/Weakness.java
@@ -2,6 +2,7 @@ package com.blaybus.blaybusbe.domain.weakness.entitiy;
 
 import com.blaybus.blaybusbe.domain.mentoring.entity.MenteeInfo;
 import com.blaybus.blaybusbe.domain.studyContent.entitiy.StudyContents;
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,10 @@ public class Weakness {
     @Column(nullable = false, length = 100)
     private String title; // 보완점
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Subject subject;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "info_id", nullable = false)
     private MenteeInfo menteeInfo; // 멘티 정보 식별자 연관관계
@@ -28,8 +33,9 @@ public class Weakness {
     private StudyContents studyContent;
 
     @Builder
-    public Weakness(String title, MenteeInfo menteeInfo, StudyContents studyContent) {
+    public Weakness(String title, Subject subject, MenteeInfo menteeInfo, StudyContents studyContent) {
         this.title = title;
+        this.subject = subject;
         this.menteeInfo = menteeInfo;
         this.studyContent = studyContent;
     }

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/enums/Subject.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/enums/Subject.java
@@ -1,0 +1,10 @@
+package com.blaybus.blaybusbe.domain.weakness.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Subject {
+    KOREAN, MATH, ENGLISH
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/repository/WeaknessRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/repository/WeaknessRepository.java
@@ -2,6 +2,7 @@ package com.blaybus.blaybusbe.domain.weakness.repository;
 
 import com.blaybus.blaybusbe.domain.mentoring.entity.MenteeInfo;
 import com.blaybus.blaybusbe.domain.weakness.entitiy.Weakness;
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,8 +11,17 @@ import org.springframework.data.repository.query.Param;
 
 public interface WeaknessRepository extends JpaRepository<Weakness, Long> {
 
-    // 멘티 정보별 약점 페이징 조회
-    @Query(value = "SELECT w FROM Weakness w LEFT JOIN FETCH w.studyContent WHERE w.menteeInfo = :menteeInfo",
-            countQuery = "SELECT count(w) FROM Weakness w WHERE w.menteeInfo = :menteeInfo")
-    Page<Weakness> findAllByMenteeInfo(@Param("menteeInfo") MenteeInfo menteeInfo, Pageable pageable);
+    // 과목 필터링을 포함한 약점 페이징 조회
+    @Query(value = "SELECT w FROM Weakness w " +
+            "LEFT JOIN FETCH w.studyContent " +
+            "WHERE w.menteeInfo = :menteeInfo " +
+            "AND (:subject IS NULL OR w.subject = :subject)",
+            countQuery = "SELECT count(w) FROM Weakness w " +
+                    "WHERE w.menteeInfo = :menteeInfo " +
+                    "AND (:subject IS NULL OR w.subject = :subject)")
+    Page<Weakness> findAllByMenteeInfoAndSubject(
+            @Param("menteeInfo") MenteeInfo menteeInfo,
+            @Param("subject") Subject subject,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/weakness/service/WeaknessService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weakness/service/WeaknessService.java
@@ -7,6 +7,7 @@ import com.blaybus.blaybusbe.domain.studyContent.repository.StudyContentReposito
 import com.blaybus.blaybusbe.domain.weakness.dto.request.RequestWeaknessDto;
 import com.blaybus.blaybusbe.domain.weakness.dto.response.ResponseWeaknessDto;
 import com.blaybus.blaybusbe.domain.weakness.entitiy.Weakness;
+import com.blaybus.blaybusbe.domain.weakness.enums.Subject;
 import com.blaybus.blaybusbe.domain.weakness.repository.WeaknessRepository;
 import com.blaybus.blaybusbe.global.exception.CustomException;
 import com.blaybus.blaybusbe.global.exception.error.ErrorCode;
@@ -45,6 +46,7 @@ public class WeaknessService {
         Weakness weakness = Weakness.builder()
                 .title(request.title())
                 .menteeInfo(menteeInfo)
+                .subject(request.subject())
                 .studyContent(studyContent)
                 .build();
 
@@ -56,14 +58,15 @@ public class WeaknessService {
      *
      * @param mentorId 멘토 id
      * @param menteeId 멘티 id
+     * @param subject 과목
      * @param pageable 페이지네이션
      */
-    public Page<ResponseWeaknessDto> getMenteeWeaknesses(Long mentorId, Long menteeId, Pageable pageable) {
+    public Page<ResponseWeaknessDto> getMenteeWeaknesses(Long mentorId, Long menteeId, Subject subject, Pageable pageable) {
         // 멘토, 멘티 관계 검증
         MenteeInfo menteeInfo = menteeInfoRepository.findByMentorIdAndMenteeId(mentorId, menteeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MENTEE_INFO_NOT_FOUND));
 
-        return weaknessRepository.findAllByMenteeInfo(menteeInfo, pageable)
+        return weaknessRepository.findAllByMenteeInfoAndSubject(menteeInfo, subject, pageable)
                 .map(response -> ResponseWeaknessDto.from(response));
     }
 
@@ -71,15 +74,16 @@ public class WeaknessService {
      * 멘티가 본인의 보완점 목록 조회
      *
      * @param menteeId 멘티 id
+     * @param subject 과목
      * @param pageable 페이지네이션
      */
-    public Page<ResponseWeaknessDto> getMyWeaknesses(Long menteeId, Pageable pageable) {
+    public Page<ResponseWeaknessDto> getMyWeaknesses(Long menteeId, Subject subject, Pageable pageable) {
         // 멘티 정보를 찾음
         MenteeInfo menteeInfo = menteeInfoRepository.findByMenteeId(menteeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MENTEE_INFO_NOT_FOUND));
 
         // 해당 멘티의 약점 페이징 조회
-        return weaknessRepository.findAllByMenteeInfo(menteeInfo, pageable)
+        return weaknessRepository.findAllByMenteeInfoAndSubject(menteeInfo, subject, pageable)
                 .map(response -> ResponseWeaknessDto.from(response));
     }
 


### PR DESCRIPTION
### 주요 변경 사항

#### 1. 약점(보완점) 과목별 필터링 기능 추가
* **구현 내용**: 멘토와 멘티가 보완점 목록을 조회할 때, 전체 조회뿐만 아니라 국어(KOREAN), 수학(MATH), 영어(ENGLISH) 등 과목별로 필터링하여 조회할 수 있는 기능을 추가했습니다.
* **동적 쿼리 적용**: `WeaknessRepository`에서 `Subject` 파라미터가 `null`일 경우 전체를 조회하고, 값이 있을 경우 해당 과목만 필터링하도록 JPQL을 개선했습니다.

#### 2. 엔티티 구조 변경 및 데이터 정합성 확보
* **컬럼 추가**: `Weakness` 엔티티에 `Subject` 열거형(Enum) 컬럼을 추가하고, 데이터 무결성을 위해 `NOT NULL` 제약 조건을 설정했습니다.
* **성능 최적화**: 목록 조회 시 `LEFT JOIN FETCH`를 사용하여 연관된 학습 자료(`StudyContents`) 정보를 한 번의 쿼리로 가져오도록 최적화했습니다.

#### 3. 유효성 검증 로직 수정 (Bug Fix)
* **문제 해결**: Enum 타입인 `subject` 필드에 문자열 전용인 `@NotBlank`를 사용 시 발생하던 `UnexpectedTypeException`을 확인하여 `@NotNull`로 수정 및 안정화했습니다.
* **DTO 강화**: `RequestWeaknessDto`에 Swagger 명세와 유효성 검증 어노테이션을 보완하여 API 사용 편의성을 높였습니다.

### 기술적 의사결정
* **EnumType.STRING 사용**: DB에 순서(Ordinal)가 아닌 문자열로 저장하여, 추후 Enum 순서가 바뀌더라도 데이터가 오염되지 않도록 설계했습니다.
* **Fetch Join 전략**: 멘토링 서비스 특성상 학습 자료 연동이 잦으므로, N+1 문제를 원천 차단하기 위해 페치 조인을 필수적으로 적용했습니다.

close #54 