### PR TITLE
fix: Task 과제 출제 리팩토링 및 개선 

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
@@ -30,7 +30,7 @@ import java.util.List;
 public interface TaskApi {
 
     @Operation(summary = "멘토 과제 출제",
-            description = "멘토가 멘티에게 과제를 출제합니다. date만 전달하면 단일 과제, startDate/endDate/daysOfWeek를 전달하면 반복 과제를 일괄 생성합니다.")
+            description = "멘토가 멘티에게 과제를 출제합니다. 과목, 주차, 요일을 선택하고 startDate~endDate 범위 내 선택된 요일에 Task를 일괄 생성합니다. 요일별로 다른 학습지(contentId)를 매핑할 수 있습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "과제 출제 성공",
                     content = @Content(schema = @Schema(implementation = RecurringTaskResponse.class))),

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateMentorTaskRequest.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/request/CreateMentorTaskRequest.java
@@ -7,20 +7,17 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record CreateMentorTaskRequest(
-        Subject subject,
-        String title,
-        Long weaknessId,
-
-        // 단일 과제: date만 전달
-        LocalDate date,
-
-        // 반복 과제: startDate + endDate + daysOfWeek 전달
-        LocalDate startDate,
-        LocalDate endDate,
-        List<DayOfWeekEnum> daysOfWeek
+        Subject subject,                    // 과목 1개
+        Integer weekNumber,                 // 주차 (숫자, 표시용)
+        LocalDate startDate,                // 시작일
+        LocalDate endDate,                  // 종료일
+        List<DayOfWeekEnum> daysOfWeek,     // 요일 복수선택
+        String title,                       // 제목
+        Long weaknessId,                    // nullable (보완점 선택 시)
+        List<DayContentMapping> dayContents // 요일별 학습지 매핑
 ) {
-    public boolean isRecurring() {
-        return daysOfWeek != null && !daysOfWeek.isEmpty()
-                && startDate != null && endDate != null;
-    }
+    public record DayContentMapping(
+            DayOfWeekEnum day,
+            Long contentId
+    ) {}
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
@@ -20,6 +20,7 @@ public record TaskResponse(
         Boolean isMandatory,
         Boolean isMentorChecked,
         String recurringGroupId,
+        Integer weekNumber,
         TimerStatus timerStatus,
         Long weaknessId,
         Long contentId,
@@ -46,6 +47,7 @@ public record TaskResponse(
                 .isMandatory(task.getIsMandatory())
                 .isMentorChecked(task.getIsMentorChecked())
                 .recurringGroupId(task.getRecurringGroupId())
+                .weekNumber(task.getWeekNumber())
                 .timerStatus(task.getTimerStatus())
                 .weaknessId(task.getWeaknessId())
                 .contentId(task.getContentId())
@@ -53,7 +55,7 @@ public record TaskResponse(
                 .fileUrl(fileUrl)
                 .dailyPlanId(task.getDailyPlan().getId())
                 .menteeId(task.getMentee().getId())
-                .submitted(false) // Submission 도메인 미구현 → 항상 false
+                .submitted(task.getStatus() == TaskStatus.DONE)
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
                 .build();

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
@@ -62,6 +62,9 @@ public class Task extends BaseTimeEntity {
     @Column(name = "weakness_id")
     private Long weaknessId; // 보완점 ID
 
+    @Column(name = "week_number")
+    private Integer weekNumber; // 주차 (표시용)
+
     @Column(name = "content_id")
     private Long contentId; // 일반 학습 자료 ID 추가
 
@@ -76,6 +79,7 @@ public class Task extends BaseTimeEntity {
     @Builder
     public Task(Subject subject, String title, LocalDate taskDate,
                 Boolean isMandatory, String recurringGroupId, Long weaknessId,
+                Integer weekNumber, Long contentId,
                 DailyPlan dailyPlan, User mentee) {
         this.subject = subject;
         this.title = title;
@@ -83,6 +87,8 @@ public class Task extends BaseTimeEntity {
         this.isMandatory = isMandatory != null ? isMandatory : false;
         this.recurringGroupId = recurringGroupId;
         this.weaknessId = weaknessId;
+        this.weekNumber = weekNumber;
+        this.contentId = contentId;
         this.dailyPlan = dailyPlan;
         this.mentee = mentee;
         this.status = TaskStatus.TODO;

--- a/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     TIMER_ALREADY_RUNNING(409, "타이머가 이미 실행 중입니다."),
     TIMER_NOT_RUNNING(409, "타이머가 실행 중이 아닙니다."),
     RECURRING_GROUP_NOT_FOUND(404, "반복 과제 그룹을 찾을 수 없습니다."),
+    INVALID_DAY_CONTENT_MAPPING(400, "요일별 학습지 매핑이 올바르지 않습니다."),
     MENTEE_INFO_NOT_FOUND(404, "멘토-멘티 매핑 정보를 찾을 수 없습니다."),
 
     // 학습자료 관련 오류


### PR DESCRIPTION
## Summary
- 멘토 과제 출제를 주차+요일 기반으로 리팩토링, 요일별 학습지(contentId) 매핑 지원
- Task 엔티티에 weekNumber, contentId 필드 추가
- 단일/반복 과제 분기 제거 → 통합 생성 로직으로 간소화
- TaskResponse.submitted를 하드코딩(false)에서 status == DONE 기반으로 수정
- INVALID_DAY_CONTENT_MAPPING 에러 코드 추가

## Test plan
- [x] 멘토 과제 출제 API 호출 시 주차/요일/학습지 매핑 정상 동작 확인
- [x] 과제 제출 후 TaskResponse.submitted가 true로 반환되는지 확인
- [x] 잘못된 요일-학습지 매핑 시 400 에러 반환 확인

Closes #51