### PR TITLE
Feature: 피드백 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/FeedbackController.java
@@ -2,12 +2,18 @@ package com.blaybus.blaybusbe.domain.feedback.controller;
 
 import com.blaybus.blaybusbe.domain.feedback.controller.api.FeedbackApi;
 import com.blaybus.blaybusbe.domain.feedback.dto.request.UpdateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackListResponse;
 import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackResponse;
 import com.blaybus.blaybusbe.domain.feedback.service.FeedbackService;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
 import com.blaybus.blaybusbe.global.s3.S3Service;
 import com.blaybus.blaybusbe.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -82,5 +88,34 @@ public class FeedbackController implements FeedbackApi {
     ) {
         feedbackService.deleteFeedback(user.getId(), feedbackId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @GetMapping("/feedbacks/yesterday")
+    public ResponseEntity<Page<FeedbackListResponse>> getYesterdayFeedbacks(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        return ResponseEntity.ok(feedbackService.getYesterdayFeedbacks(
+                user.getId(), PageRequest.of(page, size)));
+    }
+
+    @Override
+    @GetMapping("/feedbacks/history")
+    public ResponseEntity<Page<FeedbackListResponse>> getFeedbackHistory(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam Long menteeId,
+            @RequestParam(required = false) Subject subject,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month,
+            @RequestParam(required = false) Integer weekNumber,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) {
+        return ResponseEntity.ok(feedbackService.getFeedbackHistory(
+                user.getId(), menteeId, subject, year, month, startDate, endDate, PageRequest.of(page, size)));
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/api/FeedbackApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/controller/api/FeedbackApi.java
@@ -1,16 +1,20 @@
 package com.blaybus.blaybusbe.domain.feedback.controller.api;
 
 import com.blaybus.blaybusbe.domain.feedback.dto.request.UpdateFeedbackRequest;
+import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackListResponse;
 import com.blaybus.blaybusbe.domain.feedback.dto.response.FeedbackResponse;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
 import com.blaybus.blaybusbe.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "Feedback", description = "이미지 좌표 기반 피드백 API")
@@ -62,5 +66,37 @@ public interface FeedbackApi {
     ResponseEntity<Void> deleteFeedback(
             @Parameter(hidden = true) CustomUserDetails user,
             @Parameter(description = "피드백 ID") Long feedbackId
+    );
+
+    @Operation(summary = "어제자 피드백 목록 조회", description = "어제 생성된 피드백 목록을 페이징 조회합니다. 멘티 본인만 조회 가능합니다. 정렬은 최신순(createdAt DESC) 고정입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<Page<FeedbackListResponse>> getYesterdayFeedbacks(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
+            @Parameter(description = "페이지 크기", example = "10") Integer size
+    );
+
+    @Operation(summary = "이전 피드백 모아보기",
+            description = "피드백 생성일 기준으로 과목, 년도, 월, 주차, 시작일, 종료일로 필터링하여 이전 피드백을 페이징 조회합니다. " +
+                    "프론트에서 주차 선택 시 startDate/endDate로 날짜 범위를 전달하고, weekNumber는 표시용으로 함께 전달합니다. " +
+                    "menteeId == 본인 ID면 멘티 본인 조회, 다른 ID면 멘토-멘티 매핑 검증 후 조회. " +
+                    "정렬은 최신순(createdAt DESC) 고정입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "멘토-멘티 매핑이 존재하지 않음")
+    })
+    ResponseEntity<Page<FeedbackListResponse>> getFeedbackHistory(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "멘티 ID (멘티 본인 ID 또는 멘토가 조회할 멘티 ID)", required = true) Long menteeId,
+            @Parameter(description = "과목 필터") Subject subject,
+            @Parameter(description = "년도 필터", example = "2026") Integer year,
+            @Parameter(description = "월 필터 (1~12)", example = "2") Integer month,
+            @Parameter(description = "주차 (프론트 표시용, 필터는 startDate/endDate로 적용)", example = "1") Integer weekNumber,
+            @Parameter(description = "시작일", example = "2026-02-01") LocalDate startDate,
+            @Parameter(description = "종료일", example = "2026-02-07") LocalDate endDate,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") Integer page,
+            @Parameter(description = "페이지 크기", example = "10") Integer size
     );
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/response/FeedbackListResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/response/FeedbackListResponse.java
@@ -1,0 +1,43 @@
+package com.blaybus.blaybusbe.domain.feedback.dto.response;
+
+import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record FeedbackListResponse(
+        Long feedbackId,
+        String content,
+        String imageUrl,
+        Float xPos,
+        Float yPos,
+        String mentorName,
+        Integer commentCount,
+        LocalDateTime createdAt,
+        Long taskId,
+        String taskTitle,
+        Subject subject,
+        LocalDate taskDate,
+        Integer weekNumber
+) {
+    public static FeedbackListResponse from(TaskFeedback feedback, int commentCount) {
+        return FeedbackListResponse.builder()
+                .feedbackId(feedback.getId())
+                .content(feedback.getContent())
+                .imageUrl(feedback.getImageUrl())
+                .xPos(feedback.getXPos())
+                .yPos(feedback.getYPos())
+                .mentorName(feedback.getMentor().getName())
+                .commentCount(commentCount)
+                .createdAt(feedback.getCreatedAt())
+                .taskId(feedback.getTask().getId())
+                .taskTitle(feedback.getTask().getTitle())
+                .subject(feedback.getTask().getSubject())
+                .taskDate(feedback.getTask().getTaskDate())
+                .weekNumber(feedback.getTask().getWeekNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/repository/TaskFeedbackRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/repository/TaskFeedbackRepository.java
@@ -1,10 +1,14 @@
 package com.blaybus.blaybusbe.domain.feedback.repository;
 
 import com.blaybus.blaybusbe.domain.feedback.entity.TaskFeedback;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TaskFeedbackRepository extends JpaRepository<TaskFeedback, Long> {
@@ -14,4 +18,40 @@ public interface TaskFeedbackRepository extends JpaRepository<TaskFeedback, Long
 
     @Query("SELECT COUNT(f) FROM TaskFeedback f WHERE f.image.id = :imageId")
     int countByImageId(@Param("imageId") Long imageId);
+
+    // 어제자 피드백 목록 조회 (피드백 생성일 기준, 페이징)
+    @Query(value = "SELECT f FROM TaskFeedback f JOIN FETCH f.mentor JOIN FETCH f.task " +
+            "WHERE f.task.mentee.id = :menteeId " +
+            "AND CAST(f.createdAt AS localdate) = :yesterday " +
+            "ORDER BY f.createdAt DESC",
+            countQuery = "SELECT COUNT(f) FROM TaskFeedback f " +
+                    "WHERE f.task.mentee.id = :menteeId " +
+                    "AND CAST(f.createdAt AS localdate) = :yesterday")
+    Page<TaskFeedback> findYesterdayFeedbacks(@Param("menteeId") Long menteeId,
+                                              @Param("yesterday") LocalDate yesterday,
+                                              Pageable pageable);
+
+    // 이전 피드백 모아보기 (피드백 생성일 기준 필터링 + 페이징)
+    @Query(value = "SELECT f FROM TaskFeedback f JOIN FETCH f.mentor JOIN FETCH f.task " +
+            "WHERE f.task.mentee.id = :menteeId " +
+            "AND (:subject IS NULL OR f.task.subject = :subject) " +
+            "AND (:year IS NULL OR YEAR(f.createdAt) = :year) " +
+            "AND (:month IS NULL OR MONTH(f.createdAt) = :month) " +
+            "AND (:startDate IS NULL OR CAST(f.createdAt AS localdate) >= :startDate) " +
+            "AND (:endDate IS NULL OR CAST(f.createdAt AS localdate) <= :endDate) " +
+            "ORDER BY f.createdAt DESC",
+            countQuery = "SELECT COUNT(f) FROM TaskFeedback f " +
+                    "WHERE f.task.mentee.id = :menteeId " +
+                    "AND (:subject IS NULL OR f.task.subject = :subject) " +
+                    "AND (:year IS NULL OR YEAR(f.createdAt) = :year) " +
+                    "AND (:month IS NULL OR MONTH(f.createdAt) = :month) " +
+                    "AND (:startDate IS NULL OR CAST(f.createdAt AS localdate) >= :startDate) " +
+                    "AND (:endDate IS NULL OR CAST(f.createdAt AS localdate) <= :endDate)")
+    Page<TaskFeedback> findFeedbacksWithFilters(@Param("menteeId") Long menteeId,
+                                                @Param("subject") Subject subject,
+                                                @Param("year") Integer year,
+                                                @Param("month") Integer month,
+                                                @Param("startDate") LocalDate startDate,
+                                                @Param("endDate") LocalDate endDate,
+                                                Pageable pageable);
 }


### PR DESCRIPTION
## Summary
- 어제자 피드백 목록 조회 (`GET /feedbacks/yesterday`): 피드백 생성일 기준, 멘티 본인만 조회, 페이징
- 이전 피드백 모아보기 (`GET /feedbacks/history`): 과목/년도/월/시작일/종료일 필터 + 페이징
  - menteeId 필수: 본인 ID면 멘티 조회, 다른 ID면 멘토-멘티 매핑 검증 후 조회
  - weekNumber는 프론트 표시용으로만 전달 (서버 필터링에 미사용)
- `FeedbackListResponse` DTO 추가 (과제 정보 포함: taskTitle, subject, taskDate, weekNumber)

## Test plan
- [x] 멘티 토큰으로 어제자 피드백 조회 정상 동작 확인
- [x] 멘토 토큰으로 어제자 피드백 조회 시 403 반환 확인
- [x] 이전 피드백 모아보기: 멘티 본인 ID로 조회 정상 동작 확인
- [x] 이전 피드백 모아보기: 멘토가 매핑된 멘티 ID로 조회 정상 동작 확인
- [x] 이전 피드백 모아보기: 매핑 안 된 멘티 ID로 조회 시 403 반환 확인
- [x] 과목/년도/월/날짜범위 필터 조합 정상 동작 확인

Closes #58