### PR TITLE
Fix: 멘토 피드백 작성 시 is_mentor_checked 자동 체크

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
@@ -83,6 +83,9 @@ public class FeedbackService {
 
         feedbackRepository.save(feedback);
 
+        // 피드백 작성 시 멘토 확인 체크 자동 처리
+        image.getSubmission().getTask().setIsMentorChecked(true);
+
         // 멘티에게 피드백 알림 발행
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.FEEDBACK,


### PR DESCRIPTION
## Summary
- 멘토가 이미지 좌표 피드백을 작성할 때 해당 과제의 `is_mentor_checked`가 자동으로 `true`로 변경되도록 수정
- `FeedbackService.createFeedback()` 내 피드백 저장 후 Task의 `isMentorChecked` 필드를 `true`로 설정하는 로직 추가

## Test plan
- [x] 멘토로 로그인하여 제출된 과제에 이미지 좌표 피드백 작성
- [x] 피드백 작성 후 해당 과제의 `isMentorChecked`가 `true`로 변경되었는지 확인
- [x] 기존 멘토 확인 토글 API (`PATCH /mentor/tasks/{taskId}/confirm`)가 정상 동작하는지 확인

close #61 