### PR TITLE
Feature: 과목별 공부시간 집계 및 버그 수정 

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/entity/Answer.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/entity/Answer.java
@@ -35,6 +35,7 @@ public class Answer extends BaseTimeEntity {
     @Builder
     public Answer(String comment, User user, TaskFeedback feedback) {
         this.comment = comment;
+        this.isMentorRead = false;
         this.user = user;
         this.feedback = feedback;
     }

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/PlanResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/PlanResponse.java
@@ -3,17 +3,21 @@ package com.blaybus.blaybusbe.domain.plan.dto.response;
 import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
 import com.blaybus.blaybusbe.domain.task.dto.response.TaskResponse;
 import com.blaybus.blaybusbe.domain.task.entity.Task;
+import com.blaybus.blaybusbe.domain.task.enums.Subject;
 import lombok.Builder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Builder
 public record PlanResponse(
         Long id,
         LocalDate planDate,
         Integer totalStudyTime,
+        Map<String, Integer> studyTimeSummary,
         String dailyMemo,
         String mentorFeedback,
         Long menteeId,
@@ -22,10 +26,19 @@ public record PlanResponse(
 ) {
 
     public static PlanResponse from(DailyPlan plan, List<Task> taskList) {
+        Map<String, Integer> summary = new HashMap<>();
+        for (Subject s : Subject.values()) {
+            summary.put(s.name(), taskList.stream()
+                    .filter(t -> t.getSubject() == s)
+                    .mapToInt(Task::getActualStudyTime)
+                    .sum());
+        }
+
         return PlanResponse.builder()
                 .id(plan.getId())
                 .planDate(plan.getPlanDate())
                 .totalStudyTime(plan.getTotalStudyTime())
+                .studyTimeSummary(summary)
                 .dailyMemo(plan.getDailyMemo())
                 .mentorFeedback(plan.getMentorFeedback())
                 .menteeId(plan.getMentee().getId())


### PR DESCRIPTION
## Summary
- PlanResponse에 `studyTimeSummary` 필드 추가 (KOREAN, ENGLISH, MATH, OTHER 과목별 공부시간 집계)
- Answer 엔티티 Builder에서 `isMentorRead` 기본값 누락으로 인한 H2 NOT NULL 오류 수정

## Test plan
- [x] 플래너 조회 시 studyTimeSummary가 과목별로 정상 집계되는지 확인
- [x] 댓글 생성 시 IS_MENTOR_READ NULL 오류가 발생하지 않는지 확인
- [x] 기존 totalStudyTime 필드가 그대로 유지되는지 확인

close #63 