### PR TITLE
Feature:  공부 시간 단위를 분에서 초로 변경 및 표시 형식 개선

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/CalendarDayResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/CalendarDayResponse.java
@@ -1,6 +1,7 @@
 package com.blaybus.blaybusbe.domain.plan.dto.response;
 
 import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
+import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -9,7 +10,8 @@ import java.time.LocalDate;
 public record CalendarDayResponse(
         Long planId,
         LocalDate planDate,
-        Integer totalStudyTime,
+        Long totalStudyTime,
+        String totalStudyTimeFormatted,
         boolean hasMemo
 ) {
 
@@ -18,6 +20,7 @@ public record CalendarDayResponse(
                 .planId(plan.getId())
                 .planDate(plan.getPlanDate())
                 .totalStudyTime(plan.getTotalStudyTime())
+                .totalStudyTimeFormatted(TimeUtils.formatSecondsToHHMMSS(plan.getTotalStudyTime()))
                 .hasMemo(plan.getDailyMemo() != null && !plan.getDailyMemo().isBlank())
                 .build();
     }

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/PlanResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/dto/response/PlanResponse.java
@@ -1,5 +1,6 @@
 package com.blaybus.blaybusbe.domain.plan.dto.response;
 
+import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
 import com.blaybus.blaybusbe.domain.task.dto.response.TaskResponse;
 import com.blaybus.blaybusbe.domain.task.entity.Task;
@@ -16,8 +17,9 @@ import java.util.Map;
 public record PlanResponse(
         Long id,
         LocalDate planDate,
-        Integer totalStudyTime,
-        Map<String, Integer> studyTimeSummary,
+        Long totalStudyTime,
+        String totalStudyTimeFormatted,
+        Map<String, Long> studyTimeSummary,
         String dailyMemo,
         String mentorFeedback,
         Long menteeId,
@@ -26,11 +28,11 @@ public record PlanResponse(
 ) {
 
     public static PlanResponse from(DailyPlan plan, List<Task> taskList) {
-        Map<String, Integer> summary = new HashMap<>();
+        Map<String, Long> summary = new HashMap<>();
         for (Subject s : Subject.values()) {
             summary.put(s.name(), taskList.stream()
                     .filter(t -> t.getSubject() == s)
-                    .mapToInt(Task::getActualStudyTime)
+                    .mapToLong(Task::getActualStudyTime)
                     .sum());
         }
 
@@ -38,6 +40,7 @@ public record PlanResponse(
                 .id(plan.getId())
                 .planDate(plan.getPlanDate())
                 .totalStudyTime(plan.getTotalStudyTime())
+                .totalStudyTimeFormatted(TimeUtils.formatSecondsToHHMMSS(plan.getTotalStudyTime()))
                 .studyTimeSummary(summary)
                 .dailyMemo(plan.getDailyMemo())
                 .mentorFeedback(plan.getMentorFeedback())

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/entity/DailyPlan.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/entity/DailyPlan.java
@@ -27,7 +27,7 @@ public class DailyPlan extends BaseTimeEntity {
     private LocalDate planDate;
 
     @Column(name = "total_study_time", nullable = false)
-    private Integer totalStudyTime = 0;
+    private Long totalStudyTime = 0L;
 
     @Column(name = "daily_memo", columnDefinition = "TEXT")
     private String dailyMemo;
@@ -44,6 +44,6 @@ public class DailyPlan extends BaseTimeEntity {
         this.planDate = planDate;
         this.dailyMemo = dailyMemo;
         this.mentee = mentee;
-        this.totalStudyTime = 0;
+        this.totalStudyTime = 0L;
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
@@ -104,12 +104,12 @@ public class TaskController implements TaskApi {
     }
 
     @Override
-    @GetMapping("/tasks/{taskId}/logs")
-    public ResponseEntity<List<TaskLogResponse>> getTaskLogs(
+    @GetMapping("/tasks/{taskId}/accumulated-study-time")
+    public ResponseEntity<TaskResponse> getAccumulatedStudyTimeForTask(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long taskId
     ) {
-        return ResponseEntity.ok(taskService.getTaskLogs(taskId));
+        return ResponseEntity.ok(taskService.getAccumulatedStudyTimeForTask(taskId));
     }
 
     @Override

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
@@ -124,12 +124,13 @@ public interface TaskApi {
             @Parameter(description = "과제 ID") @PathVariable Long taskId
     );
 
-    @Operation(summary = "타이머 기록 조회", description = "과제의 타이머 세션 기록 목록을 조회합니다.")
+    @Operation(summary = "과제 누적 학습 시간 조회", description = "과제의 총 누적 학습 시간을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
             @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
     })
-    ResponseEntity<List<TaskLogResponse>> getTaskLogs(
+    ResponseEntity<TaskResponse> getAccumulatedStudyTimeForTask(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
             @Parameter(description = "과제 ID") @PathVariable Long taskId
     );

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskLogResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskLogResponse.java
@@ -1,5 +1,6 @@
 package com.blaybus.blaybusbe.domain.task.dto.response;
 
+import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import com.blaybus.blaybusbe.domain.task.entity.TaskLog;
 import lombok.Builder;
 
@@ -11,7 +12,8 @@ public record TaskLogResponse(
         Long taskId,
         LocalDateTime startAt,
         LocalDateTime endAt,
-        Integer duration
+        Long duration,
+        String durationFormatted
 ) {
     public static TaskLogResponse from(TaskLog taskLog) {
         return TaskLogResponse.builder()
@@ -20,6 +22,7 @@ public record TaskLogResponse(
                 .startAt(taskLog.getStartAt())
                 .endAt(taskLog.getEndAt())
                 .duration(taskLog.getDuration())
+                .durationFormatted(TimeUtils.formatSecondsToHHMMSS(taskLog.getDuration()))
                 .build();
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
@@ -1,5 +1,6 @@
 package com.blaybus.blaybusbe.domain.task.dto.response;
 
+import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import com.blaybus.blaybusbe.domain.task.entity.Task;
 import com.blaybus.blaybusbe.domain.task.enums.Subject;
 import com.blaybus.blaybusbe.domain.task.enums.TaskStatus;
@@ -15,7 +16,8 @@ public record TaskResponse(
         Subject subject,
         String title,
         TaskStatus status,
-        Integer actualStudyTime,
+        Long actualStudyTime,
+        String actualStudyTimeFormatted,
         LocalDate taskDate,
         Boolean isMandatory,
         Boolean isMentorChecked,
@@ -43,6 +45,7 @@ public record TaskResponse(
                 .title(task.getTitle())
                 .status(task.getStatus())
                 .actualStudyTime(task.getActualStudyTime())
+                .actualStudyTimeFormatted(TimeUtils.formatSecondsToHHMMSS(task.getActualStudyTime()))
                 .taskDate(task.getTaskDate())
                 .isMandatory(task.getIsMandatory())
                 .isMentorChecked(task.getIsMentorChecked())

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerStopResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerStopResponse.java
@@ -1,11 +1,18 @@
 package com.blaybus.blaybusbe.domain.task.dto.response;
 
+import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import lombok.Builder;
 
 @Builder
 public record TimerStopResponse(
         Long taskId,
-        Integer sessionMinutes,
-        Integer accumulatedMinutes
+        Long sessionSeconds,
+        String sessionFormatted,
+        Long accumulatedSeconds,
+        String accumulatedFormatted
 ) {
+
+    public static String formatTime(Long totalSeconds) {
+        return TimeUtils.formatSecondsToHHMMSS(totalSeconds);
+    }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
@@ -38,7 +38,7 @@ public class Task extends BaseTimeEntity {
     private TaskStatus status = TaskStatus.TODO;
 
     @Column(name = "actual_study_time", nullable = false)
-    private Integer actualStudyTime = 0;
+    private Long actualStudyTime = 0L;
 
     @Column(name = "task_date", nullable = false)
     private LocalDate taskDate;
@@ -92,7 +92,7 @@ public class Task extends BaseTimeEntity {
         this.dailyPlan = dailyPlan;
         this.mentee = mentee;
         this.status = TaskStatus.TODO;
-        this.actualStudyTime = 0;
+        this.actualStudyTime = 0L;
         this.isMentorChecked = false;
         this.timerStatus = TimerStatus.STOPPED;
     }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/entity/TaskLog.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/entity/TaskLog.java
@@ -28,10 +28,10 @@ public class TaskLog {
     private LocalDateTime endAt;
 
     @Column(nullable = false)
-    private Integer duration;
+    private Long duration;
 
     @Builder
-    public TaskLog(Task task, LocalDateTime startAt, LocalDateTime endAt, Integer duration) {
+    public TaskLog(Task task, LocalDateTime startAt, LocalDateTime endAt, Long duration) {
         this.task = task;
         this.startAt = startAt;
         this.endAt = endAt;

--- a/src/main/java/com/blaybus/blaybusbe/global/common/util/TimeUtils.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/common/util/TimeUtils.java
@@ -1,0 +1,16 @@
+package com.blaybus.blaybusbe.global.common.util;
+
+public class TimeUtils {
+
+    public static String formatSecondsToHHMMSS(Long totalSeconds) {
+        if (totalSeconds == null || totalSeconds < 0) {
+            return "00:00:00";
+        }
+
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+}


### PR DESCRIPTION
학습 시간의 저장 단위를 분에서 초로 변경하고 관련 로직 및 응답 형식을 업데이트했습니다.

 주요 변경 사항:


   1. 엔티티 (Task, DailyPlan, TaskLog) 시간 필드 타입 변경:
       * Task 엔티티의 actualStudyTime 필드를 Integer에서 Long으로 변경했습니다.
       * DailyPlan 엔티티의 totalStudyTime 필드를 Integer에서 Long으로 변경했습니다.
       * TaskLog 엔티티의 duration 필드를 Integer에서 Long으로 변경했습니다.
       * 모든 학습 시간 데이터는 이제 초 단위로 저장됩니다.


   2. DTO (TimerStopResponse, TaskResponse, TaskLogResponse, PlanResponse, CalendarDayResponse) 업데이트:
       * 관련 시간 필드의 타입을 Integer에서 Long으로 변경했습니다.
       * 클라이언트에서 시/분/초 형식으로 쉽게 표시할 수 있도록 totalStudyTimeFormatted, sessionFormatted,
         accumulatedFormatted, durationFormatted 등의 포맷된 시간 문자열 필드를 추가했습니다.


   3. 서비스 로직 (TaskService) 변경:
       * TaskService.stopTimer() 메서드의 시간 계산 및 업데이트 로직을 분 단위에서 초 단위로 변경했습니다.
       * TaskService.getTaskLogs() 메서드를 getAccumulatedStudyTimeForTask()로 리팩토링하여, 개별 로그 대신 해당 과제의
         총 누적 학습 시간(TaskResponse 형태)만 반환하도록 변경했습니다. (기존 '과제 상세 조회'(GET
         /tasks/{taskId})에서도 누적 학습 시간을 확인할 수 있으므로 중복을 피하기 위해 리팩토링)


   4. 컨트롤러 (TaskController) 및 API 인터페이스 (TaskApi) 업데이트:
       * getTaskLogs 관련 엔드포인트명, 반환 타입, Swagger 설명을 getAccumulatedStudyTimeForTask에 맞춰 변경했습니다.


   5. 새로운 유틸리티 클래스 (TimeUtils) 추가:
       * 초 단위를 "HH:MM:SS" 형식의 문자열로 변환하는 TimeUtils.formatSecondsToHHMMSS() 메서드를 포함하는 TimeUtils
         클래스를 global.common.util 패키지에 추가하여 시간 형식 변환을 중앙화했습니다.


  이 변경사항을 통해 학습 시간 데이터의 정밀도가 향상되고, 클라이언트에서 시간을 보다 유연하고 사용자 친화적인 형식으로
  표시할 수 있게 되었습니다.