### PR TITLE
fix: 미사용 API 및 필드 제거

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/PlanController.java
@@ -87,22 +87,6 @@ public class PlanController implements PlanApi {
     }
 
     @Override
-    @GetMapping("/calendar/weekly")
-    public ResponseEntity<Page<PlanResponse>> getWeeklyCalendar(
-            @AuthenticationPrincipal CustomUserDetails user,
-            @RequestParam(required = false) Long menteeId,
-            @RequestParam String date,
-            @PageableDefault(size = 7, sort = "planDate") Pageable pageable
-    ) {
-        if (menteeId != null && !menteeInfoRepository.existsByMentorIdAndMenteeId(user.getId(), menteeId)) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
-        }
-        Long targetMenteeId = menteeId != null ? menteeId : user.getId();
-        LocalDate targetDate = LocalDate.parse(date);
-        return ResponseEntity.ok(planService.getWeeklyCalendar(targetMenteeId, targetDate, pageable));
-    }
-
-    @Override
     @PutMapping("/{planId}")
     public ResponseEntity<PlanResponse> updatePlan(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/api/PlanApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/controller/api/PlanApi.java
@@ -68,18 +68,6 @@ public interface PlanApi {
             @Parameter(hidden = true) Pageable pageable
     );
 
-    @Operation(summary = "주간 캘린더 조회", description = "특정 날짜가 포함된 주(월~일)의 플래너와 할 일 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "주간 캘린더 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content)
-    })
-    ResponseEntity<Page<PlanResponse>> getWeeklyCalendar(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
-            @RequestParam(required = false) Long menteeId,
-            @Parameter(description = "조회 기준 날짜 (yyyy-MM-dd)") @RequestParam String date,
-            @Parameter(hidden = true) Pageable pageable
-    );
-
     @Operation(summary = "플래너 수정", description = "플래너 메모를 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "플래너 수정 성공",

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/service/PlanService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/service/PlanService.java
@@ -9,7 +9,6 @@ import com.blaybus.blaybusbe.domain.plan.entity.DailyPlan;
 import com.blaybus.blaybusbe.domain.plan.repository.DailyPlanRepository;
 import com.blaybus.blaybusbe.domain.task.entity.Task;
 import com.blaybus.blaybusbe.domain.task.enums.Subject;
-import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.time.YearMonth;
 import java.time.LocalDate;
@@ -32,7 +31,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.blaybus.blaybusbe.domain.plan.dto.response.TaskSummaryResponse;
 import java.util.Collections;
 import java.util.List;
-import java.time.DayOfWeek;
 
 @Service
 @Transactional
@@ -146,23 +144,6 @@ public class PlanService {
                     List<TaskSummaryResponse> tasks = tasksByDailyPlanId.getOrDefault(plan.getId(), Collections.emptyList());
                     return CalendarDayResponse.from(plan, tasks);
                 });
-    }
-
-    /**
-     * 주간 캘린더 조회 (해당 날짜가 속한 주 월~일)
-     */
-    @Transactional(readOnly = true)
-    public Page<PlanResponse> getWeeklyCalendar(Long menteeId, LocalDate date, Pageable pageable) {
-        LocalDate monday = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDate sunday = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
-
-        Page<DailyPlan> plans = dailyPlanRepository.findByMenteeIdAndPlanDateBetween(menteeId, monday, sunday, pageable);
-
-        return plans.map(plan -> {
-            List<Task> tasks = taskRepository.findByDailyPlanId(plan.getId());
-            List<DailyPlanTaskResponse> dailyPlanTasks = tasks.stream().map(DailyPlanTaskResponse::from).toList();
-            return PlanResponse.from(plan, dailyPlanTasks);
-        });
     }
 
     /**

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
@@ -113,16 +113,6 @@ public class TaskController implements TaskApi {
     }
 
     @Override
-    @DeleteMapping("/mentor/recurring-tasks/{recurringGroupId}")
-    public ResponseEntity<Void> deleteRecurringTasks(
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PathVariable String recurringGroupId
-    ) {
-        taskService.deleteRecurringTasks(user.getId(), recurringGroupId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @Override
     @GetMapping("/mentor/tasks/list/{menteeId}")
     public ResponseEntity<List<TaskResponse>> getTaskListByMentor(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
@@ -135,17 +135,6 @@ public interface TaskApi {
             @Parameter(description = "과제 ID") @PathVariable Long taskId
     );
 
-    @Operation(summary = "반복 과제 그룹 삭제", description = "같은 반복 그룹의 과제를 일괄 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
-            @ApiResponse(responseCode = "404", description = "반복 그룹 없음", content = @Content)
-    })
-    ResponseEntity<Void> deleteRecurringTasks(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
-            @Parameter(description = "반복 그룹 ID") @PathVariable String recurringGroupId
-    );
-
     @Operation(summary = "[멘토] 멘티의 날짜별 과제 목록 조회", description = "멘토가 담당 멘티의 특정 날짜 과제 목록을 조회합니다.")
     ResponseEntity<List<TaskResponse>> getTaskListByMentor(
             @Parameter(hidden = true)

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/RecurringTaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/RecurringTaskResponse.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 @Builder
 public record RecurringTaskResponse(
-        String recurringGroupId,
         Integer taskCount,
         List<TaskResponse> tasks
 ) {

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
@@ -21,7 +21,6 @@ public record TaskResponse(
         LocalDate taskDate,
         Boolean isMandatory,
         Boolean isMentorChecked,
-        String recurringGroupId,
         Integer weekNumber,
         TimerStatus timerStatus,
         Long weaknessId,
@@ -49,7 +48,6 @@ public record TaskResponse(
                 .taskDate(task.getTaskDate())
                 .isMandatory(task.getIsMandatory())
                 .isMentorChecked(task.getIsMentorChecked())
-                .recurringGroupId(task.getRecurringGroupId())
                 .weekNumber(task.getWeekNumber())
                 .timerStatus(task.getTimerStatus())
                 .weaknessId(task.getWeaknessId())

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/entity/Task.java
@@ -49,9 +49,6 @@ public class Task extends BaseTimeEntity {
     @Column(name = "is_mandatory", nullable = false)
     private Boolean isMandatory = false;
 
-    @Column(name = "recurring_group_id")
-    private String recurringGroupId;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "timer_status", nullable = false)
     private TimerStatus timerStatus = TimerStatus.STOPPED;
@@ -78,14 +75,13 @@ public class Task extends BaseTimeEntity {
 
     @Builder
     public Task(Subject subject, String title, LocalDate taskDate,
-                Boolean isMandatory, String recurringGroupId, Long weaknessId,
+                Boolean isMandatory, Long weaknessId,
                 Integer weekNumber, Long contentId,
                 DailyPlan dailyPlan, User mentee) {
         this.subject = subject;
         this.title = title;
         this.taskDate = taskDate;
         this.isMandatory = isMandatory != null ? isMandatory : false;
-        this.recurringGroupId = recurringGroupId;
         this.weaknessId = weaknessId;
         this.weekNumber = weekNumber;
         this.contentId = contentId;

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/repository/TaskRepository.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/repository/TaskRepository.java
@@ -14,8 +14,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     List<Task> findByMenteeIdAndTaskDate(Long menteeId, LocalDate taskDate);
 
-    List<Task> findByRecurringGroupId(String recurringGroupId);
-
     List<Task> findByTaskDateAndStatusNot(LocalDate taskDate, TaskStatus status);
 
     List<Task> findByDailyPlanIdIn(List<Long> dailyPlanIds);

--- a/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/exception/error/ErrorCode.java
@@ -26,7 +26,6 @@ public enum ErrorCode {
     TASK_NOT_MODIFIABLE(403, "해당 과제를 수정/삭제할 권한이 없습니다."),
     TIMER_ALREADY_RUNNING(409, "타이머가 이미 실행 중입니다."),
     TIMER_NOT_RUNNING(409, "타이머가 실행 중이 아닙니다."),
-    RECURRING_GROUP_NOT_FOUND(404, "반복 과제 그룹을 찾을 수 없습니다."),
     INVALID_DAY_CONTENT_MAPPING(400, "요일별 학습지 매핑이 올바르지 않습니다."),
     MENTEE_INFO_NOT_FOUND(404, "멘토-멘티 매핑 정보를 찾을 수 없습니다."),
 


### PR DESCRIPTION
## Summary
- Task 엔티티에서 `recurringGroupId` 필드 제거
- 반복 과제 그룹 삭제 API 제거 (`DELETE /mentor/recurring-tasks/{recurringGroupId}`)
- 주간 캘린더 조회 API 제거 (`GET /plans/calendar/weekly`)
- 관련 DTO, Repository, Service, ErrorCode 정리

## Test plan
- [x] 빌드 성공 확인
- [x] 멘토 과제 출제 API 정상 동작 확인
- [x] 월간 캘린더 조회 API 정상 동작 확인