### PR TITLE
Feature: exposedHeaders 설정을 추가

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/blaybus/blaybusbe/global/config/SecurityConfig.java
@@ -83,6 +83,8 @@ public class SecurityConfig {
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 
+        config.setExposedHeaders(List.of("Authorization"));
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;


### PR DESCRIPTION
### 작업 내용
* **CORS 설정 업데이트**: 브라우저 환경에서 프론트엔드가 응답 헤더의 `Authorization`(JWT) 값을 읽을 수 있도록 `exposedHeaders` 설정을 추가하였습니다.
* **Git 환경 정리**: 로컬 DB 데이터 파일(`mysql_data/`)이 소스 제어에 포함되어 발생하는 병합 충돌을 방지하기 위해, 해당 폴더를 Git 추적 대상에서 제외하고 `.gitignore`를 업데이트하였습니다.

### 🛠 변경 사항
* `SecurityConfig.java`: `config.setExposedHeaders(List.of("Authorization"))` 설정 추가
* `.gitignore`: `mysql_data/` 항목 추가 및 기존 추적 캐시 삭제