### PR TITLE
Feature: API 응답 필드 보강 및 TaskLog 조회 API 추가 

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/dto/response/CommentResponse.java
@@ -13,17 +13,19 @@ public class CommentResponse {
 
     private Long id;
     private String comment;
+    private LocalDateTime createdAt;
+    private Long userId;
     private String authorName;
     private Role role;
-    private LocalDateTime createdAt;
 
     public static CommentResponse from(Answer answer) {
         return CommentResponse.builder()
                 .id(answer.getId())
                 .comment(answer.getComment())
+                .createdAt(answer.getCreatedAt())
+                .userId(answer.getUser().getId())
                 .authorName(answer.getUser().getName())
                 .role(answer.getUser().getRole())
-                .createdAt(answer.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/dto/response/FeedbackResponse.java
@@ -15,6 +15,7 @@ public class FeedbackResponse {
     private String imageUrl;
     private Float xPos;
     private Float yPos;
+    private Long mentorId;
     private String mentorName;
     private Integer commentCount;
     private LocalDateTime createdAt;
@@ -26,6 +27,7 @@ public class FeedbackResponse {
                 .imageUrl(feedback.getImageUrl())
                 .xPos(feedback.getXPos())
                 .yPos(feedback.getYPos())
+                .mentorId(feedback.getMentor().getId())
                 .mentorName(feedback.getMentor().getName())
                 .commentCount(commentCount)
                 .createdAt(feedback.getCreatedAt())

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
@@ -113,6 +113,15 @@ public class TaskController implements TaskApi {
     }
 
     @Override
+    @GetMapping("/tasks/{taskId}/logs")
+    public ResponseEntity<List<TaskLogResponse>> getTaskLogs(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long taskId
+    ) {
+        return ResponseEntity.ok(taskService.getTaskLogs(user.getId(), taskId));
+    }
+
+    @Override
     @GetMapping("/mentor/tasks/list/{menteeId}")
     public ResponseEntity<List<TaskResponse>> getTaskListByMentor(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
@@ -135,6 +135,18 @@ public interface TaskApi {
             @Parameter(description = "과제 ID") @PathVariable Long taskId
     );
 
+    @Operation(summary = "과제별 타이머 로그 목록 조회",
+            description = "과제의 타이머 세션 기록을 조회합니다. MENTEE는 본인 과제, MENTOR는 담당 멘티 과제만 조회 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
+    })
+    ResponseEntity<List<TaskLogResponse>> getTaskLogs(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "과제 ID") @PathVariable Long taskId
+    );
+
     @Operation(summary = "[멘토] 멘티의 날짜별 과제 목록 조회", description = "멘토가 담당 멘티의 특정 날짜 과제 목록을 조회합니다.")
     ResponseEntity<List<TaskResponse>> getTaskListByMentor(
             @Parameter(hidden = true)

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskLogResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskLogResponse.java
@@ -1,6 +1,5 @@
 package com.blaybus.blaybusbe.domain.task.dto.response;
 
-import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import com.blaybus.blaybusbe.domain.task.entity.TaskLog;
 import lombok.Builder;
 
@@ -12,8 +11,7 @@ public record TaskLogResponse(
         Long taskId,
         LocalDateTime startAt,
         LocalDateTime endAt,
-        Long duration,
-        String durationFormatted
+        Long duration
 ) {
     public static TaskLogResponse from(TaskLog taskLog) {
         return TaskLogResponse.builder()
@@ -22,7 +20,6 @@ public record TaskLogResponse(
                 .startAt(taskLog.getStartAt())
                 .endAt(taskLog.getEndAt())
                 .duration(taskLog.getDuration())
-                .durationFormatted(TimeUtils.formatSecondsToHHMMSS(taskLog.getDuration()))
                 .build();
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TaskResponse.java
@@ -1,6 +1,5 @@
 package com.blaybus.blaybusbe.domain.task.dto.response;
 
-import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import com.blaybus.blaybusbe.domain.task.entity.Task;
 import com.blaybus.blaybusbe.domain.task.enums.Subject;
 import com.blaybus.blaybusbe.domain.task.enums.TaskStatus;
@@ -17,7 +16,6 @@ public record TaskResponse(
         String title,
         TaskStatus status,
         Long actualStudyTime,
-        String actualStudyTimeFormatted,
         LocalDate taskDate,
         Boolean isMandatory,
         Boolean isMentorChecked,
@@ -44,7 +42,6 @@ public record TaskResponse(
                 .title(task.getTitle())
                 .status(task.getStatus())
                 .actualStudyTime(task.getActualStudyTime())
-                .actualStudyTimeFormatted(TimeUtils.formatSecondsToHHMMSS(task.getActualStudyTime()))
                 .taskDate(task.getTaskDate())
                 .isMandatory(task.getIsMandatory())
                 .isMentorChecked(task.getIsMentorChecked())

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerStopResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/dto/response/TimerStopResponse.java
@@ -1,18 +1,11 @@
 package com.blaybus.blaybusbe.domain.task.dto.response;
 
-import com.blaybus.blaybusbe.global.common.util.TimeUtils;
 import lombok.Builder;
 
 @Builder
 public record TimerStopResponse(
         Long taskId,
         Long sessionSeconds,
-        String sessionFormatted,
-        Long accumulatedSeconds,
-        String accumulatedFormatted
+        Long accumulatedSeconds
 ) {
-
-    public static String formatTime(Long totalSeconds) {
-        return TimeUtils.formatSecondsToHHMMSS(totalSeconds);
-    }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
@@ -29,7 +29,7 @@ import com.blaybus.blaybusbe.domain.weakness.entitiy.Weakness;
 import com.blaybus.blaybusbe.domain.weakness.repository.WeaknessRepository;
 import com.blaybus.blaybusbe.global.exception.CustomException;
 import com.blaybus.blaybusbe.global.exception.error.ErrorCode;
-import com.blaybus.blaybusbe.global.common.util.TimeUtils;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -293,9 +293,7 @@ public class TaskService {
         return TimerStopResponse.builder()
                 .taskId(task.getId())
                 .sessionSeconds(sessionSeconds)
-                .sessionFormatted(TimeUtils.formatSecondsToHHMMSS(sessionSeconds))
                 .accumulatedSeconds(task.getActualStudyTime())
-                .accumulatedFormatted(TimeUtils.formatSecondsToHHMMSS(task.getActualStudyTime()))
                 .build();
     }
 
@@ -310,6 +308,23 @@ public class TaskService {
         validateTaskViewPermission(task, userId);
 
         return TaskResponse.from(task);
+    }
+
+    /**
+     * 과제별 타이머 로그 목록 조회
+     * MENTEE: 본인 과제 로그만 조회 가능
+     * MENTOR: 담당 멘티의 과제 로그만 조회 가능
+     */
+    @Transactional(readOnly = true)
+    public List<TaskLogResponse> getTaskLogs(Long userId, Long taskId) {
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
+
+        validateTaskViewPermission(task, userId);
+
+        return taskLogRepository.findByTaskId(taskId).stream()
+                .map(TaskLogResponse::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- TaskLog 조회 API 추가 (`GET /tasks/{taskId}/logs`) — 과제별 타이머 세션 기록 조회
- 댓글 응답(`CommentResponse`)에 `userId` 필드 추가 — 프론트에서 본인 댓글 수정/삭제 버튼 노출
- 피드백 응답(`FeedbackResponse`)에 `mentorId` 필드 추가 — 멘토 본인 피드백 수정/삭제 버튼 노출
- `TaskResponse`, `TimerStopResponse`, `TaskLogResponse`에서 불필요한 서버 포맷팅 필드 제거 (프론트에서 초 단위 직접 처리)

## Test plan
- [x] Swagger에서 `GET /tasks/{taskId}/logs` 호출하여 타이머 로그 배열 반환 확인
- [x] `POST /feedback/{feedbackId}/comments` 응답에 `userId` 포함 확인
- [x] `GET /images/{imageId}/feedback` 응답에 `mentorId` 포함 확인
- [x] 기존 타이머 start/stop API 정상 동작 확인

close #75 