### PR TITLE
fix: 불필요한 누적학습시간 조회 API 제거 

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/TaskController.java
@@ -104,15 +104,6 @@ public class TaskController implements TaskApi {
     }
 
     @Override
-    @GetMapping("/tasks/{taskId}/accumulated-study-time")
-    public ResponseEntity<TaskResponse> getAccumulatedStudyTimeForTask(
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PathVariable Long taskId
-    ) {
-        return ResponseEntity.ok(taskService.getAccumulatedStudyTimeForTask(user.getId(), taskId));
-    }
-
-    @Override
     @GetMapping("/tasks/{taskId}/logs")
     public ResponseEntity<List<TaskLogResponse>> getTaskLogs(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/controller/api/TaskApi.java
@@ -124,17 +124,6 @@ public interface TaskApi {
             @Parameter(description = "과제 ID") @PathVariable Long taskId
     );
 
-    @Operation(summary = "과제 누적 학습 시간 조회", description = "과제의 총 누적 학습 시간을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공",
-                    content = @Content(schema = @Schema(implementation = TaskResponse.class))),
-            @ApiResponse(responseCode = "404", description = "과제 없음", content = @Content)
-    })
-    ResponseEntity<TaskResponse> getAccumulatedStudyTimeForTask(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
-            @Parameter(description = "과제 ID") @PathVariable Long taskId
-    );
-
     @Operation(summary = "과제별 타이머 로그 목록 조회",
             description = "과제의 타이머 세션 기록을 조회합니다. MENTEE는 본인 과제, MENTOR는 담당 멘티 과제만 조회 가능합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
@@ -298,19 +298,6 @@ public class TaskService {
     }
 
     /**
-     * 타이머 기록 조회
-     */
-    @Transactional(readOnly = true)
-    public TaskResponse getAccumulatedStudyTimeForTask(Long userId, Long taskId) {
-        Task task = taskRepository.findById(taskId)
-                .orElseThrow(() -> new CustomException(ErrorCode.TASK_NOT_FOUND));
-
-        validateTaskViewPermission(task, userId);
-
-        return TaskResponse.from(task);
-    }
-
-    /**
      * 과제별 타이머 로그 목록 조회
      * MENTEE: 본인 과제 로그만 조회 가능
      * MENTOR: 담당 멘티의 과제 로그만 조회 가능


### PR DESCRIPTION
## Summary
- `GET /tasks/{taskId}/accumulated-study-time` 엔드포인트 제거
- 과제 상세 조회(`GET /tasks/{taskId}`)의 `actualStudyTime` 필드로 이미 동일한 정보 제공

## Test plan
- [x] `GET /tasks/{taskId}` 응답에 `actualStudyTime` 정상 포함 확인
- [x] Swagger에서 accumulated-study-time 엔드포인트 제거 확인