### PR TITLE
Feature: 알림 라우팅 필드 추가 

### DIFF
--- a/src/main/java/com/blaybus/blaybusbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/comment/service/CommentService.java
@@ -58,10 +58,15 @@ public class CommentService {
 
         // 상대방에게 댓글 알림 발행
         Long recipientId = userId.equals(mentorId) ? menteeId : mentorId;
+        Long taskId = feedback.getTask().getId();
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.COMMENT,
                 recipientId,
-                String.format("%s님이 댓글을 작성했습니다.", user.getName())
+                String.format("%s님이 댓글을 작성했습니다.", user.getName()),
+                feedbackId,    // targetId = feedbackId
+                feedbackId,
+                taskId,
+                menteeId
         ));
 
         return CommentResponse.from(answer);

--- a/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/feedback/service/FeedbackService.java
@@ -87,10 +87,15 @@ public class FeedbackService {
         image.getSubmission().getTask().setIsMentorChecked(true);
 
         // 멘티에게 피드백 알림 발행
+        Long taskId = image.getSubmission().getTask().getId();
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.FEEDBACK,
                 menteeId,
-                String.format("%s 멘토님이 피드백을 작성했습니다.", mentor.getName())
+                String.format("%s 멘토님이 피드백을 작성했습니다.", mentor.getName()),
+                feedback.getId(),  // targetId = feedbackId
+                feedback.getId(),
+                taskId,
+                menteeId
         ));
 
         return FeedbackResponse.from(feedback, answerRepository.countByFeedbackId(feedback.getId()));

--- a/src/main/java/com/blaybus/blaybusbe/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/notification/dto/response/NotificationResponse.java
@@ -17,6 +17,13 @@ public class NotificationResponse {
     private Boolean isRead;
     private LocalDateTime createdAt;
 
+    // 프론트 라우팅용 필드
+    private String targetType;
+    private Long targetId;
+    private Long feedbackId;
+    private Long taskId;
+    private Long menteeId;
+
     public static NotificationResponse from(Notification notification) {
         return NotificationResponse.builder()
                 .id(notification.getId())
@@ -24,6 +31,11 @@ public class NotificationResponse {
                 .message(notification.getMessage())
                 .isRead(notification.getIsRead())
                 .createdAt(notification.getCreatedAt())
+                .targetType(notification.getType().name())
+                .targetId(notification.getTargetId())
+                .feedbackId(notification.getFeedbackId())
+                .taskId(notification.getTaskId())
+                .menteeId(notification.getMenteeId())
                 .build();
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/notification/entity/Notification.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/notification/entity/Notification.java
@@ -32,12 +32,30 @@ public class Notification extends BaseCreateEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    // 프론트 라우팅용 필드
+    @Column(name = "target_id")
+    private Long targetId;
+
+    @Column(name = "feedback_id")
+    private Long feedbackId;
+
+    @Column(name = "task_id")
+    private Long taskId;
+
+    @Column(name = "mentee_id")
+    private Long menteeId;
+
     @Builder
-    public Notification(NotificationType type, String message, User user) {
+    public Notification(NotificationType type, String message, User user,
+                        Long targetId, Long feedbackId, Long taskId, Long menteeId) {
         this.type = type;
         this.message = message;
         this.user = user;
         this.isRead = false;
+        this.targetId = targetId;
+        this.feedbackId = feedbackId;
+        this.taskId = taskId;
+        this.menteeId = menteeId;
     }
 
     public void markAsRead() {

--- a/src/main/java/com/blaybus/blaybusbe/domain/notification/event/NotificationEvent.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/notification/event/NotificationEvent.java
@@ -5,6 +5,14 @@ import com.blaybus.blaybusbe.domain.notification.enums.NotificationType;
 public record NotificationEvent(
         NotificationType type,
         Long recipientUserId,
-        String message
+        String message,
+        Long targetId,
+        Long feedbackId,
+        Long taskId,
+        Long menteeId
 ) {
+    // 기존 호환용 생성자 (targetId, feedbackId, taskId, menteeId 없는 경우)
+    public NotificationEvent(NotificationType type, Long recipientUserId, String message) {
+        this(type, recipientUserId, message, null, null, null, null);
+    }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/notification/event/NotificationEventListener.java
@@ -19,7 +19,15 @@ public class NotificationEventListener {
         log.info("알림 이벤트 수신: type={}, userId={}, message={}",
                 event.type(), event.recipientUserId(), event.message());
         try {
-            notificationService.send(event.type(), event.recipientUserId(), event.message());
+            notificationService.send(
+                    event.type(),
+                    event.recipientUserId(),
+                    event.message(),
+                    event.targetId(),
+                    event.feedbackId(),
+                    event.taskId(),
+                    event.menteeId()
+            );
             log.info("알림 저장 완료: type={}, userId={}", event.type(), event.recipientUserId());
         } catch (Exception e) {
             log.error("알림 처리 실패: type={}, userId={}, message={}",

--- a/src/main/java/com/blaybus/blaybusbe/domain/notification/service/FcmService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/notification/service/FcmService.java
@@ -7,11 +7,13 @@ import com.google.firebase.messaging.Notification;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 @Slf4j
 @Service
 public class FcmService {
 
-    public void sendPush(String fcmToken, String title, String body) {
+    public void sendPush(String fcmToken, String title, String body, Map<String, String> data) {
         if (fcmToken == null || fcmToken.isBlank()) {
             log.debug("FCM 토큰이 없어 푸시 전송을 건너뜁니다.");
             return;
@@ -23,18 +25,26 @@ public class FcmService {
         }
 
         try {
-            Message message = Message.builder()
+            Message.Builder messageBuilder = Message.builder()
                     .setToken(fcmToken)
                     .setNotification(Notification.builder()
                             .setTitle(title)
                             .setBody(body)
-                            .build())
-                    .build();
+                            .build());
 
-            String response = FirebaseMessaging.getInstance().send(message);
+            if (data != null && !data.isEmpty()) {
+                messageBuilder.putAllData(data);
+            }
+
+            String response = FirebaseMessaging.getInstance().send(messageBuilder.build());
             log.debug("FCM 푸시 전송 성공: {}", response);
         } catch (Exception e) {
             log.error("FCM 푸시 전송 실패: token={}, title={}", fcmToken, title, e);
         }
+    }
+
+    // 기존 호환용 오버로드
+    public void sendPush(String fcmToken, String title, String body) {
+        sendPush(fcmToken, title, body, null);
     }
 }

--- a/src/main/java/com/blaybus/blaybusbe/domain/plan/service/PlanService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/plan/service/PlanService.java
@@ -206,7 +206,11 @@ public class PlanService {
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.PLAN_FEEDBACK,
                 plan.getMentee().getId(),
-                String.format("%s 멘토님이 플래너 피드백을 작성했습니다.", mentor.getName())
+                String.format("%s 멘토님이 플래너 피드백을 작성했습니다.", mentor.getName()),
+                planId,        // targetId = planId
+                null,
+                null,
+                plan.getMentee().getId()
         ));
 
         return PlanFeedbackResponse.from(plan, mentor.getName());

--- a/src/main/java/com/blaybus/blaybusbe/domain/submission/service/SubmissionService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/submission/service/SubmissionService.java
@@ -83,7 +83,11 @@ public class SubmissionService {
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.SUBMISSION,
                 mentorId,
-                String.format("%s 학생이 과제를 제출했습니다: %s", menteeName, task.getTitle())
+                String.format("%s 학생이 과제를 제출했습니다: %s", menteeName, task.getTitle()),
+                taskId,        // targetId = taskId
+                null,
+                taskId,
+                userId         // menteeId = 제출한 멘티
         ));
 
         return SubmissionResponse.from(submission);

--- a/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/task/service/TaskService.java
@@ -110,10 +110,15 @@ public class TaskService {
         // 멘티에게 과제 출제 알림
         User mentor = userRepository.findById(mentorId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Long firstTaskId = createdTasks.isEmpty() ? null : createdTasks.get(0).getId();
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.TASK,
                 menteeId,
-                String.format("%s 멘토님이 새 과제를 출제했습니다: %s", mentor.getName(), request.title())
+                String.format("%s 멘토님이 새 과제를 출제했습니다: %s", mentor.getName(), request.title()),
+                firstTaskId,   // targetId = 첫 번째 생성된 과제 ID
+                null,
+                firstTaskId,
+                menteeId
         ));
 
         return RecurringTaskResponse.builder()

--- a/src/main/java/com/blaybus/blaybusbe/domain/weeklyReport/service/WeeklyReportService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/weeklyReport/service/WeeklyReportService.java
@@ -51,7 +51,11 @@ public class WeeklyReportService {
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.WEEKLY_REPORT,
                 request.menteeId(),
-                String.format("%s 멘토님이 주간 리포트를 작성했습니다.", mentor.getName())
+                String.format("%s 멘토님이 주간 리포트를 작성했습니다.", mentor.getName()),
+                reportId,      // targetId = reportId
+                null,
+                null,
+                request.menteeId()
         ));
 
         return reportId;

--- a/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/service/ZoomFeedbackService.java
+++ b/src/main/java/com/blaybus/blaybusbe/domain/zoomfeedback/service/ZoomFeedbackService.java
@@ -46,7 +46,11 @@ public class ZoomFeedbackService {
         eventPublisher.publishEvent(new NotificationEvent(
                 NotificationType.ZOOM_FEEDBACK,
                 menteeId,
-                String.format("%s 멘토님이 줌 미팅 피드백을 작성했습니다.", menteeInfo.getMentor().getName())
+                String.format("%s 멘토님이 줌 미팅 피드백을 작성했습니다.", menteeInfo.getMentor().getName()),
+                feedbackId,    // targetId = zoomFeedbackId
+                null,
+                null,
+                menteeId
         ));
 
         return feedbackId;


### PR DESCRIPTION
## Summary
- 알림 응답에 `targetType`, `targetId`, `feedbackId`, `taskId`, `menteeId` 필드 추가
- 프론트에서 알림 클릭 시 정확한 페이지(피드백 확장, 과제 상세 등)로 이동 가능
- FCM 푸시 알림에도 data payload로 라우팅 정보 포함

## 변경 파일
- **Notification 엔티티/DTO**: 라우팅 필드 4개 추가 (targetId, feedbackId, taskId, menteeId)
- **NotificationEvent**: 라우팅 필드 추가 + 기존 3파라미터 호환 생성자 유지
- **NotificationService/EventListener**: 새 필드 전달 로직
- **FcmService**: data payload 지원 추가
- **7개 서비스**: 각 알림 타입별 적절한 라우팅 ID 전달

## 알림 타입별 전달 필드
| 타입 | targetId | feedbackId | taskId | menteeId |
|------|----------|-----------|--------|----------|
| COMMENT | feedbackId | feedbackId | taskId | menteeId |
| FEEDBACK | feedbackId | feedbackId | taskId | menteeId |
| SUBMISSION | taskId | - | taskId | menteeId |
| TASK | - | - | - | menteeId |
| PLAN_FEEDBACK | planId | - | - | menteeId |
| WEEKLY_REPORT | reportId | - | - | menteeId |
| ZOOM_FEEDBACK | zoomFeedbackId | - | - | menteeId |
| REMINDER | - | - | - | - |

## Test plan
- [x] 각 알림 타입별 이벤트 발행 시 라우팅 필드가 정상적으로 저장되는지 확인
- [x] GET /notifications 응답에 targetType, targetId, feedbackId, taskId, menteeId 포함 확인
- [x] FCM 푸시 알림의 data payload에 라우팅 정보 포함 확인

close #78 